### PR TITLE
Minor fixes/changes to protocol documentation

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -40,20 +40,20 @@ Total length of the message (min/max range `16 / 4294967295`).
 ### Wire Type (4 bytes)
 
 - byte 1
-  - `0xff` - the message is initiated by Lair
-  - `0x00` - the request is for Lair
-  - `0x??` - undefined / reserved
+  - `0x*0` - request message
+  - `0x*1` - response message
+  - `0x*?` - undefined / reserved
 - byte 2
-  - `0x??` - undefined / reserved
-- byte 3
   - `0x00` - the message is unclassified
   - `0x01` - the message is related to TLS
   - `0x02` - the message is related to Ed25519
   - `0x??` - undefined / reserved
+- byte 3
+  - `0x??` - undefined / reserved
 - byte 4
-  - `0x*0` - request message
-  - `0x*1` - response message
-  - `0x*?` - undefined / reserved
+  - `0xff` - the message is initiated by Lair
+  - `0x00` - the request is for Lair
+  - `0x??` - undefined / reserved
 
 ### Message ID (8 bytes)
 An identifier used to match a response to the intial request.
@@ -66,11 +66,11 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### Unlock Passphrase
 
-#### `0xff000010` Request payload
+#### `4278190096` Request payload
 
 - empty
 
-#### `0xff000011` Response payload
+#### `4278190097` Response payload
 
 - `8+` byte - passphrase (string)
   - `8` bytes (unsigned-LE) for length
@@ -78,34 +78,34 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### Get Last Entry
 
-#### `0x00000010` Request payload
+#### `16` Request payload
 
 - empty
 
-#### `0x00000011` Response payload
+#### `17` Response payload
 
 - `4` byte (unsigned-LE) - last keystore index
 
 ### Get Entry Type
 
-#### `0x00000020` Request payload
+#### `32` Request payload
 
 - `4` byte (unsigned-LE) - keystore index
 
-#### `0x00000021` Response payload
+#### `33` Response payload
 
 - `4` byte (unsigned-LE) - entry type
-  - `0x00000000` - Invalid
-  - `0x00000100` - TLS Certificate
-  - `0x00000200` - Ed25519
+  - `0` - Invalid
+  - `256` - TLS Certificate
+  - `512` - Ed25519
 
 ### Get Server Info
 
-#### `0x00000030` Request payload
+#### `48` Request payload
 
 - empty
 
-#### `0x00000031` Response payload
+#### `49` Response payload
 
 - `8+` byte - server name
   - `8` bytes (unsigned-LE) for length
@@ -116,14 +116,14 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### TLS - Create Self-signed Certificate from Entropy
 
-#### `0x00000110` Request payload
+#### `272` Request payload
 
 - `4` byte (unsigned-LE) - TLS certificate algorithm
-  - `0x00000200` - Ed25519
-  - `0x00000201` - EcDSA P-256
-  - `0x00000202` - EcDSA P-384
+  - `512` - Ed25519
+  - `513` - EcDSA P-256
+  - `514` - EcDSA P-384
 
-#### `0x00000111` Response payload
+#### `273` Response payload
 
 - `4` byte (unsigned-LE) - keystore index
 - `8+` byte - certificate SNI
@@ -133,11 +133,11 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### TLS - Get Certificate
 
-#### `0x00000120` Request payload
+#### `288` Request payload
 
 - `4` byte (unsigned-LE) - keystore index
 
-#### `0x00000121` Response payload
+#### `289` Response payload
 
 - `8+` byte - certificate SNI
   - `8` bytes (unsigned-LE) for length
@@ -147,11 +147,11 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### TLS - Get Certificate by Index
 
-#### `0x00000130` Request payload
+#### `304` Request payload
 
 - `4` byte (unsigned-LE) - keystore index
 
-#### `0x00000131` Response payload
+#### `305` Response payload
 
 - `8` byte (unsigned-LE) - certificate length
 - `+` byte - certificate
@@ -159,11 +159,11 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### TLS - Get Certificate by Digest
 
-#### `0x00000140` Request payload
+#### `320` Request payload
 
 - `32` byte - certificate digest
 
-#### `0x00000141` Response payload
+#### `321` Response payload
 
 - `8` byte (unsigned-LE) - certificate length
 - `+` byte - certificate
@@ -171,13 +171,13 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### TLS - Get Certificate by SNI
 
-#### `0x00000150` Request payload
+#### `336` Request payload
 
 - `8+` byte - certificate SNI
   - `8` bytes (unsigned-LE) for length
   - `+` bytes for `utf8` encoded certificate SNI
 
-#### `0x00000151` Response payload
+#### `337` Response payload
 
 - `8` byte (unsigned-LE) - certificate length
 - `+` byte - certificate
@@ -185,11 +185,11 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### TLS - Get Private Key by Index
 
-#### `0x00000160` Request payload
+#### `352` Request payload
 
 - `4` byte (unsigned-LE) - keystore index
 
-#### `0x00000161` Response payload
+#### `353` Response payload
 
 - `8` byte (unsigned-LE) - certificate private key length
 - `+` byte - certificate private key
@@ -197,11 +197,11 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### TLS - Get Private Key by Digest
 
-#### `0x00000170` Request payload
+#### `368` Request payload
 
 - `32` byte - certificate digest
 
-#### `0x00000171` Response payload
+#### `369` Response payload
 
 - `8` byte (unsigned-LE) - certificate private key length
 - `+` byte - certificate private key
@@ -209,13 +209,13 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### TLS - Get Private Key by SNI
 
-#### `0x00000180` Request payload
+#### `384` Request payload
 
 - `8+` byte - certificate SNI
   - `8` bytes (unsigned-LE) for length
   - `+` bytes for `utf8` encoded certificate SNI
 
-#### `0x00000181` Response payload
+#### `385` Response payload
 
 - `8` byte (unsigned-LE) - certificate private key length
 - `+` byte - certificate private key
@@ -223,11 +223,11 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### Ed25519 - Create a New Key from Entropy
 
-#### `0x00000210` Request payload
+#### `528` Request payload
 
 - empty
 
-#### `0x00000211` Response payload
+#### `529` Response payload
 
 - `4` byte (unsigned-LE) - keystore index
 - `32` byte - public key
@@ -235,36 +235,36 @@ Can be any number of bytes.  The payload format is determined by the wire type.
 
 ### Ed25519 - Get Public Key by Index
 
-#### `0x00000220` Request payload
+#### `544` Request payload
 
 - `4` byte (unsigned-LE) - keystore index
 
-#### `0x00000221` Response payload
+#### `545` Response payload
 
 - `32` byte - public key
 
 
 ### Ed25519 - Sign by Index
 
-#### `0x00000230` Request payload
+#### `560` Request payload
 
 - `4` byte (unsigned-LE) - keystore index
 - `8` byte (unsigned-LE) - message length
 - `+` byte - message
 
-#### `0x00000231` Response payload
+#### `561` Response payload
 
 - `64` byte - signature
 
 
 ### Ed25519 - Sign by Public Key
 
-#### `0x00000230` Request payload
+#### `576` Request payload
 
 - `32` byte - public key
 - `8` byte (unsigned-LE) - message length
 - `+` byte - message
 
-#### `0x00000231` Response payload
+#### `577` Response payload
 
 - `64` byte - signature


### PR DESCRIPTION
### Changes
- fix byte order for wire type to represent LE order
- replace misleading hex values with actual number values
- fix sign by pubkey wire type number