### PR TITLE
Add ErrorResponse variant to LairWire

### DIFF
--- a/crates/lair_keystore/src/ipc.rs
+++ b/crates/lair_keystore/src/ipc.rs
@@ -85,6 +85,7 @@ impl InternalApiHandler for Internal {
 impl ghost_actor::GhostHandler<LairClientApi> for Internal {}
 
 impl lair_keystore_api::actor::LairClientApiHandler for Internal {
+    #[allow(clippy::field_reassign_with_default)]
     fn handle_lair_get_server_info(
         &mut self,
     ) -> LairClientApiHandlerResult<LairServerInfo> {

--- a/crates/lair_keystore_api/src/actor.rs
+++ b/crates/lair_keystore_api/src/actor.rs
@@ -50,7 +50,7 @@ impl TlsCertAlg {
             x if x == PkcsEd25519 as u32 => PkcsEd25519,
             x if x == PkcsEcdsaP256Sha256 as u32 => PkcsEcdsaP256Sha256,
             x if x == PkcsEcdsaP384Sha384 as u32 => PkcsEcdsaP384Sha384,
-            _ => return Err("invalide tls cert alg".into()),
+            _ => return Err("invalid tls cert alg".into()),
         })
     }
 }

--- a/crates/lair_keystore_api/src/entry.rs
+++ b/crates/lair_keystore_api/src/entry.rs
@@ -269,7 +269,7 @@ mod tests {
         let d = LairEntry::from(e.clone()).encode().unwrap();
         let e2 = match LairEntry::decode(&d).unwrap() {
             LairEntry::X25519(e2) => e2,
-            e2 @ _ => panic!("unexpected type: {:?}", e2),
+            e2 => panic!("unexpected type: {:?}", e2),
         };
         assert_eq!(e.priv_key, e2.priv_key);
         assert_eq!(e.pub_key, e2.pub_key);
@@ -284,7 +284,7 @@ mod tests {
         let d = LairEntry::from(e.clone()).encode().unwrap();
         let e2 = match LairEntry::decode(&d).unwrap() {
             LairEntry::SignEd25519(e2) => e2,
-            e2 @ _ => panic!("unexpected type: {:?}", e2),
+            e2 => panic!("unexpected type: {:?}", e2),
         };
         assert_eq!(e.priv_key, e2.priv_key);
         assert_eq!(e.pub_key, e2.pub_key);
@@ -301,7 +301,7 @@ mod tests {
         let d = LairEntry::from(e.clone()).encode().unwrap();
         let e2 = match LairEntry::decode(&d).unwrap() {
             LairEntry::TlsCert(e2) => e2,
-            e2 @ _ => panic!("unexpected type: {:?}", e2),
+            e2 => panic!("unexpected type: {:?}", e2),
         };
         assert_eq!(e.sni, e2.sni);
         assert_eq!(e.priv_key_der, e2.priv_key_der);

--- a/crates/lair_keystore_api/src/internal/ipc.rs
+++ b/crates/lair_keystore_api/src/internal/ipc.rs
@@ -42,14 +42,14 @@ pub type IncomingIpcReceiver = futures::channel::mpsc::Receiver<(
 )>;
 
 ghost_actor::ghost_chan! {
-    /// Ipc wire api for both incoming api requsets and outgoing event requests.
+    /// Ipc wire api for both incoming api requests and outgoing event requests.
     pub chan IpcWireApi<LairError> {
         /// Make an Ipc request.
         fn request(msg: LairWire) -> LairWire;
     }
 }
 
-/// Spawn/bind a new ipc listener connection awaiting incomming clients.
+/// Spawn/bind a new ipc listener connection awaiting incoming clients.
 pub async fn spawn_bind_ipc(
     config: Arc<Config>,
 ) -> LairResult<(KillSwitch, IncomingIpcReceiver)> {

--- a/crates/lair_keystore_api/src/internal/ipc.rs
+++ b/crates/lair_keystore_api/src/internal/ipc.rs
@@ -205,14 +205,14 @@ impl IpcWireApiHandler for Internal {
         let weak_kill_switch = self.kill_switch.weak();
         Ok(async move {
             fut.await?;
-            Ok(weak_kill_switch
+            weak_kill_switch
                 .mix(async move {
                     trace!("await incoming request...");
                     let res = recv.await.map_err(LairError::other);
                     trace!(?res, "respond to incoming request");
                     res
                 })
-                .await?)
+                .await
         }
         .boxed()
         .into())

--- a/crates/lair_keystore_api/src/internal/wire.rs
+++ b/crates/lair_keystore_api/src/internal/wire.rs
@@ -19,6 +19,21 @@ macro_rules! default_encode_setup {
 macro_rules! wire_type_meta_macro {
     ($macro_name:ident) => {
         $macro_name! {
+            ErrorResponse 0xffffffff false false {
+                message: String,
+            }
+            |msg_id, wire_type| {
+                let mut writer = default_encode_setup!(msg_id, wire_type);
+                writer.write_str(&message, 128)?;
+                Ok(writer.into_vec())
+            } |reader| {
+                let msg_id = reader.read_u64()?;
+                let message = reader.read_str()?;
+                LairWire::ErrorResponse {
+                    msg_id,
+                    message,
+                }
+            },
             ToCliRequestUnlockPassphrase 0xff000010 true true {
             } |msg_id, wire_type| {
                 let writer = default_encode_setup!(msg_id, wire_type);

--- a/crates/lair_keystore_api/src/internal/wire.rs
+++ b/crates/lair_keystore_api/src/internal/wire.rs
@@ -875,7 +875,7 @@ macro_rules! lair_wire_type_enum {
                             LairWireType::$variant
                         }
                     )*
-                    _ => return Err("invalide wire type".into()),
+                    _ => return Err("invalid wire type".into()),
                 })
             }
         }

--- a/crates/lair_keystore_api/src/test.rs
+++ b/crates/lair_keystore_api/src/test.rs
@@ -156,8 +156,6 @@ impl LairClientApiHandler for Internal {
         let out = LairServerInfo {
             name: "[LAIR-TEST-KEYSTORE]".to_string(),
             version: crate::LAIR_VER.to_string(),
-
-            ..Default::default()
         };
 
         Ok(async move { Ok(out) }.boxed().into())


### PR DESCRIPTION
Holo's hosted infrastructure creates a lair keystore server that make signing requests to user's web browsers. These signing requests can fail, (e.g. user is not logged in) therefore we need to be able to return an error back to Holochain. Currently we just don't respond if we encounter an error, which leads to bad behavior if Holochain forgot to add a timeout.