### PR TITLE
Add log for lair-keystore-dir and also help text for main binary + config option

### DIFF
--- a/crates/lair_keystore/src/bin/lair-keystore/main.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore/main.rs
@@ -5,15 +5,19 @@
 use structopt::StructOpt;
 use tracing::*;
 
+static LAIR_KEYSTORE_ABOUT: &str = r#"A secure storage system for Holochain cryptographic keys and secrets.
+
+- one `lair-keystore` per `holochain`
+- attaches the secure storage and IPC process
+    to a directory configurable via command
+    line options. a sensible platform specific
+    dir will be used as a default dir (and be
+    logged when executed)"#;
+
 #[derive(Debug, StructOpt)]
 #[structopt(
-    name = "lair-keystore"
-    help = "lair-keystore runs an IPC process for handling the most private data (like private keys) on behalf of Holochain with a very high regard for security.
-    One and only one `holochain` instance should talk to one `lair-keystore` instance.
-    lair-keystore runs tied to a configurable directory.
-    If multiple lair-keystore instances are run they must be run from separate directories.
-    A platform specific directory will be used as a default which will be equal to directories::ProjectDirs::from(\"host\", \"Holo\", \"Lair\")
-    https://docs.rs/directories/3.0.2/directories/struct.ProjectDirs.html#examples"
+    name = "lair-keystore",
+    about = LAIR_KEYSTORE_ABOUT
 )]
 struct Opt {
     /// Print out version info and exit.
@@ -25,7 +29,8 @@ struct Opt {
         short = "d",
         long,
         env = "LAIR_DIR",
-        help = "Can be used to override the default keystore directory to run multiple instances or for other purposes"
+        help = "Can be used to override the default keystore
+directory to run multiple instances or for other purposes"
     )]
     lair_dir: Option<std::path::PathBuf>,
 }

--- a/crates/lair_keystore/src/bin/lair-keystore/main.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore/main.rs
@@ -6,7 +6,15 @@ use structopt::StructOpt;
 use tracing::*;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "lair-keystore")]
+#[structopt(
+    name = "lair-keystore"
+    help = "lair-keystore runs an IPC process for handling the most private data (like private keys) on behalf of Holochain with a very high regard for security.
+    One and only one `holochain` instance should talk to one `lair-keystore` instance.
+    lair-keystore runs tied to a configurable directory.
+    If multiple lair-keystore instances are run they must be run from separate directories.
+    A platform specific directory will be used as a default which will be equal to directories::ProjectDirs::from(\"host\", \"Holo\", \"Lair\")
+    https://docs.rs/directories/3.0.2/directories/struct.ProjectDirs.html#examples"
+)]
 struct Opt {
     /// Print out version info and exit.
     #[structopt(short, long)]

--- a/crates/lair_keystore/src/bin/lair-keystore/main.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore/main.rs
@@ -13,7 +13,7 @@ struct Opt {
     version: bool,
 
     /// Set the lair data directory.
-    #[structopt(short = "d", long, env = "LAIR_DIR")]
+    #[structopt(short = "d", long, env = "LAIR_DIR", help = "lair will run as an IPC process using this directory as its root for all aspects of persistence. a platform specific dir will be used as a default equal to directories::ProjectDirs::from(\"host\", \"Holo\", \"Lair\")"))]
     lair_dir: Option<std::path::PathBuf>,
 }
 

--- a/crates/lair_keystore/src/bin/lair-keystore/main.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore/main.rs
@@ -25,7 +25,7 @@ struct Opt {
         short = "d",
         long,
         env = "LAIR_DIR",
-        help = "lair will run as an IPC process using this directory as its root for all aspects of persistence. a platform specific dir will be used as a default equal to directories::ProjectDirs::from(\"host\", \"Holo\", \"Lair\")"
+        help = "Can be used to override the default keystore directory to run multiple instances or for other purposes"
     )]
     lair_dir: Option<std::path::PathBuf>,
 }

--- a/crates/lair_keystore/src/bin/lair-keystore/main.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore/main.rs
@@ -13,7 +13,12 @@ struct Opt {
     version: bool,
 
     /// Set the lair data directory.
-    #[structopt(short = "d", long, env = "LAIR_DIR", help = "lair will run as an IPC process using this directory as its root for all aspects of persistence. a platform specific dir will be used as a default equal to directories::ProjectDirs::from(\"host\", \"Holo\", \"Lair\")"))]
+    #[structopt(
+        short = "d",
+        long,
+        env = "LAIR_DIR",
+        help = "lair will run as an IPC process using this directory as its root for all aspects of persistence. a platform specific dir will be used as a default equal to directories::ProjectDirs::from(\"host\", \"Holo\", \"Lair\")"
+    )]
     lair_dir: Option<std::path::PathBuf>,
 }
 

--- a/crates/lair_keystore/src/lib.rs
+++ b/crates/lair_keystore/src/lib.rs
@@ -29,7 +29,7 @@ pub async fn execute_lair() -> LairResult<()> {
 
     let config = config.build();
     
-    println!("Directory in use by lair: {:?}", config.get_root_path());
+    println!("#lair-keystore-dir:{:?}#", config.get_root_path());
 
     let internal::pid_check::PidCheckResult { store_file } =
         internal::pid_check::pid_check(&config)?;

--- a/crates/lair_keystore/src/lib.rs
+++ b/crates/lair_keystore/src/lib.rs
@@ -29,7 +29,7 @@ pub async fn execute_lair() -> LairResult<()> {
 
     let config = config.build();
     
-    println!("Directory in use by lair: {}", config.root_path.clone());
+    println!("Directory in use by lair: {}", config.get_root_path());
 
     let internal::pid_check::PidCheckResult { store_file } =
         internal::pid_check::pid_check(&config)?;

--- a/crates/lair_keystore/src/lib.rs
+++ b/crates/lair_keystore/src/lib.rs
@@ -29,7 +29,7 @@ pub async fn execute_lair() -> LairResult<()> {
 
     let config = config.build();
     
-    println!("Directory in use by lair: {}", config.get_root_path());
+    println!("Directory in use by lair: {:?}", config.get_root_path());
 
     let internal::pid_check::PidCheckResult { store_file } =
         internal::pid_check::pid_check(&config)?;

--- a/crates/lair_keystore/src/lib.rs
+++ b/crates/lair_keystore/src/lib.rs
@@ -28,6 +28,8 @@ pub async fn execute_lair() -> LairResult<()> {
     }
 
     let config = config.build();
+    
+    println!("Directory in use by lair: {}", config.root_path.clone());
 
     let internal::pid_check::PidCheckResult { store_file } =
         internal::pid_check::pid_check(&config)?;


### PR DESCRIPTION
Lair keystore is an area of a lot of confusion and some challenges for app developers, and through my own trial and errors, I've made the observations that comments like these would be helpful for the lair-keystore binary. 