### PR TITLE
Windows implementation with NamedPipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,7 @@ dependencies = [
 name = "lair_keystore"
 version = "0.0.1-alpha.12"
 dependencies = [
+ "base64",
  "criterion",
  "futures",
  "ghost_actor",
@@ -838,6 +839,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing-subscriber",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/lair_keystore/Cargo.toml
+++ b/crates/lair_keystore/Cargo.toml
@@ -18,7 +18,7 @@ lair_keystore_api = { version = "=0.0.1-alpha.12", path = "../lair_keystore_api"
 structopt = "0.3"
 sysinfo = "0.15"
 thiserror = "1"
-tokio = { version = "1.7.1", features = [ "full" ] }
+tokio = { version = "1.8.1", features = [ "full" ] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 

--- a/crates/lair_keystore_api/Cargo.toml
+++ b/crates/lair_keystore_api/Cargo.toml
@@ -24,7 +24,7 @@ rayon = "1.3"
 rcgen = "0.8.5"
 ring = "0.16"
 thiserror = "1"
-tokio = { version = "1.7.1", features = [ "full" ] }
+tokio = { version = "1.8.1", features = [ "full" ] }
 toml = "0.5"
 rand = "0.7"
 crypto_box = "0.5"

--- a/crates/lair_keystore_api/Cargo.toml
+++ b/crates/lair_keystore_api/Cargo.toml
@@ -31,6 +31,9 @@ crypto_box = "0.5"
 subtle = "2.3"
 block-padding = "0.2.1"
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3.9"
+
 [dev-dependencies]
 tempfile = "3"
 tracing-subscriber = "0.2"

--- a/crates/lair_keystore_api/src/internal/ipc/win_ipc.rs
+++ b/crates/lair_keystore_api/src/internal/ipc/win_ipc.rs
@@ -1,2 +1,250 @@
-//! windows version of ipc stream tools
-//! TODO : )
+//! Windows version of ipc stream tools using  tokio::net::windows::named_pipe
+
+use crate::*;
+
+//use std::cell::UnsafeCell;
+use std::time::Duration;
+use tokio::net::windows::named_pipe::ClientOptions;
+use tokio::time;
+use winapi::shared::winerror;
+
+//use tokio::net::windows::named_pipe::ClientOptions;
+use tokio::net::windows::named_pipe::*;
+
+enum NamedPipedKind {
+   ServerRead(tokio::io::ReadHalf<NamedPipeServer>),
+   ClientRead(tokio::io::ReadHalf<NamedPipeClient>),
+   ServerWrite(tokio::io::WriteHalf<NamedPipeServer>),
+   ClientWrite(tokio::io::WriteHalf<NamedPipeClient>),
+}
+
+#[allow(dead_code)]
+pub(crate) struct IpcRead {
+   config: Arc<Config>,
+   //read_half: tokio::io::ReadHalf<tokio::net::UnixStream>,
+   //read_half: tokio::io::ReadHalf<Channel>,
+
+   read_half: NamedPipedKind,
+}
+
+impl tokio::io::AsyncRead for IpcRead {
+   fn poll_read(
+      mut self: std::pin::Pin<&mut Self>,
+      cx: &mut std::task::Context<'_>,
+      buf: &mut tokio::io::ReadBuf<'_>,
+   ) -> std::task::Poll<tokio::io::Result<()>> {
+
+      let r = &mut self.read_half;
+      match r {
+         NamedPipedKind::ServerRead(server) => {
+            //server.poll_read(cx, buf)
+            tokio::pin!(server);
+            tokio::io::AsyncRead::poll_read(server, cx, buf)
+
+         },
+         NamedPipedKind::ClientRead(client) => {
+            // client.poll_read(cx, buf)
+            tokio::pin!(client);
+            tokio::io::AsyncRead::poll_read(client, cx, buf)
+
+         },
+         _ => unreachable!(),
+      }
+
+      // let r = &mut self.read_half;
+      // tokio::pin!(r);
+      // tokio::io::AsyncRead::poll_read(r, cx, buf)
+   }
+}
+
+
+
+#[allow(dead_code)]
+pub(crate) struct IpcWrite {
+   config: Arc<Config>,
+   //write_half: tokio::io::WriteHalf<tokio::net::UnixStream>,
+   //write_half: tokio::io::WriteHalf<Channel>,
+
+   write_half: NamedPipedKind,
+}
+
+impl tokio::io::AsyncWrite for IpcWrite {
+   fn poll_write(
+      mut self: std::pin::Pin<&mut Self>,
+      cx: &mut std::task::Context<'_>,
+      buf: &[u8],
+   ) -> std::task::Poll<tokio::io::Result<usize>> {
+
+      let w = &mut self.write_half;
+      match w {
+         NamedPipedKind::ServerWrite(server) => {
+            //server.poll_read(cx, buf)
+            tokio::pin!(server);
+            tokio::io::AsyncWrite::poll_write(server, cx, buf)
+
+         },
+         NamedPipedKind::ClientWrite(client) => {
+            // client.poll_read(cx, buf)
+            tokio::pin!(client);
+            tokio::io::AsyncWrite::poll_write(client, cx, buf)
+         },
+         _ => unreachable!(),
+      }
+
+      // let r = &mut self.write_half;
+      // tokio::pin!(r);
+      // tokio::io::AsyncWrite::poll_write(r, cx, buf)
+   }
+
+
+
+   fn poll_flush(
+      mut self: std::pin::Pin<&mut Self>,
+      cx: &mut std::task::Context<'_>,
+   ) -> std::task::Poll<tokio::io::Result<()>> {
+
+      let w = &mut self.write_half;
+      match w {
+         NamedPipedKind::ServerWrite(server) => {
+            //server.poll_read(cx, buf)
+            tokio::pin!(server);
+            tokio::io::AsyncWrite::poll_flush(server, cx)
+
+         },
+         NamedPipedKind::ClientWrite(client) => {
+            // client.poll_read(cx, buf)
+            tokio::pin!(client);
+            tokio::io::AsyncWrite::poll_flush(client, cx)
+         },
+         _ => unreachable!(),
+      }
+
+      // let r = &mut self.write_half;
+      // tokio::pin!(r);
+      // tokio::io::AsyncWrite::poll_flush(r, cx)
+   }
+
+   fn poll_shutdown(
+      mut self: std::pin::Pin<&mut Self>,
+      cx: &mut std::task::Context<'_>,
+   ) -> std::task::Poll<tokio::io::Result<()>> {
+
+      let w = &mut self.write_half;
+      match w {
+         NamedPipedKind::ServerWrite(server) => {
+            //server.poll_read(cx, buf)
+            tokio::pin!(server);
+            tokio::io::AsyncWrite::poll_shutdown(server, cx)
+
+         },
+         NamedPipedKind::ClientWrite(client) => {
+            // client.poll_read(cx, buf)
+            tokio::pin!(client);
+            tokio::io::AsyncWrite::poll_shutdown(client, cx)
+         },
+         _ => unreachable!(),
+      }
+
+      // let r = &mut self.write_half;
+      // tokio::pin!(r);
+      // tokio::io::AsyncWrite::poll_shutdown(r, cx)
+   }
+}
+
+
+/// Create an IPC Client
+pub(crate) async fn ipc_connect(
+   config: Arc<Config>,
+) -> LairResult<(IpcRead, IpcWrite)> {
+
+   let pipe_path = config.get_socket_path(); //.to_string_lossy().to_string();
+
+   // let socket = tokio::net::UnixStream::connect(config.get_socket_path())
+   //    .await
+   //    .map_err(|e| {
+   //       LairError::IpcClientConnectError(
+   //          config.get_socket_path().to_string_lossy().to_string(),
+   //          e.into(),
+   //       )
+   //    })?;
+   // let (read_half, write_half) = tokio::io::split(socket);
+
+   let client = loop {
+      match ClientOptions::new().open(pipe_path) {
+         Ok(client) => break client,
+         Err(e) if e.raw_os_error() == Some(winerror::ERROR_PIPE_BUSY as i32) => (),
+         Err(e) => return Err(LairError::from("TODO sorry!")),//Err(e),
+      }
+
+      time::sleep(Duration::from_millis(50)).await;
+   };
+
+   //let half = Arc::new(client.clone());
+
+   let (read_half, write_half) = tokio::io::split(client);
+
+   Ok((
+      IpcRead {
+         config: config.clone(),
+         read_half: NamedPipedKind::ClientRead(read_half),
+      },
+      IpcWrite {
+         config,
+         write_half: NamedPipedKind::ClientWrite(write_half),
+      },
+   ))
+}
+
+
+
+
+#[allow(dead_code)]
+pub(crate) struct IpcServer {
+   config: Arc<Config>,
+   //socket: tokio::net::UnixListener,
+   server: Arc<NamedPipeServer>,
+}
+
+impl IpcServer {
+   pub fn bind(config: Arc<Config>) -> LairResult<Self> {
+
+      let _pipe_path = std::fs::remove_file(config.get_socket_path());
+
+      // let socket = tokio::net::UnixListener::bind(config.get_socket_path())
+      //    .map_err(LairError::other)?;
+
+      const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-disconnect";
+
+      let server = Arc::new(ServerOptions::new()
+         .create(PIPE_NAME)?);
+
+      Ok(Self { config, server })
+   }
+
+   pub async fn accept(&mut self) -> LairResult<(IpcRead, IpcWrite)> {
+
+      //let (con, _) = self.server.accept().await.map_err(LairError::other)?;
+
+      let _connected = self.server.connect().await?;
+
+      self.server.readable().await?;
+      self.server.writable().await?;
+
+      let server = self.server.clone();
+
+      let (read_half, write_half) = tokio::io::split(*server);
+
+      //let half = Arc::new(self.clone());
+
+      Ok((
+         IpcRead {
+            config: self.config.clone(),
+            read_half: NamedPipedKind::ServerRead(read_half),
+         },
+         IpcWrite {
+            config: self.config.clone(),
+            write_half: NamedPipedKind::ServerWrite(write_half),
+         },
+      ))
+   }
+}

--- a/crates/lair_keystore_api/src/internal/ipc/win_ipc.rs
+++ b/crates/lair_keystore_api/src/internal/ipc/win_ipc.rs
@@ -2,27 +2,13 @@
 
 use crate::*;
 
-use std::sync::{Arc};
-//use futures::lock::Mutex;
-//use futures::future::FutureExt;
-//use futures::future::BoxFuture;
-//use std::cell::RefCell;
 use std::time::Duration;
 use tokio::net::windows::named_pipe::ClientOptions;
 use tokio::time;
 use winapi::shared::winerror;
-//use std::os::windows::io::RawHandle;
-//use std::os::windows::io::AsRawHandle;
-
-//use tokio::net::windows::named_pipe::ClientOptions;
 use tokio::net::windows::named_pipe::*;
-//use tokio::runtime::Runtime;
-//use tokio::doc::os::windows::io::RawHandle;
-
 
 enum NamedPipedKind {
-   //Server(Arc<Mutex<NamedPipeServer>>),
-   //Client(Arc<Mutex<NamedPipeClient>>),
    ServerRead(tokio::io::ReadHalf<NamedPipeServer>),
    ClientRead(tokio::io::ReadHalf<NamedPipeClient>),
    ServerWrite(tokio::io::WriteHalf<NamedPipeServer>),
@@ -32,9 +18,6 @@ enum NamedPipedKind {
 #[allow(dead_code)]
 pub(crate) struct IpcRead {
    config: Arc<Config>,
-   //read_half: tokio::io::ReadHalf<tokio::net::UnixStream>,
-   //read_half: tokio::io::ReadHalf<Channel>,
-
    read_half: NamedPipedKind,
 }
 
@@ -47,39 +30,18 @@ impl tokio::io::AsyncRead for IpcRead {
 
       let r = &mut self.read_half;
       match r {
-         //NamedPipedKind::Server(locked_server) => {
-         //       Runtime::new().unwrap().block_on(async {
-         //          let mut server = locked_server.lock().await;
-         //          //server.poll_read(cx, buf)
-         //          tokio::pin!(server);
-         //          tokio::io::AsyncRead::poll_read(server, cx, buf)
-         //          //server.poll_read(cx, buf)
-         //       })
-         // },
-         // NamedPipedKind::Client(locked_client) => {
-         //    let client = Runtime::new().unwrap().block_on(async move {*locked_client.lock().await});
-         //    //server.poll_read(cx, buf)
-         //    tokio::pin!(client);
-         //    tokio::io::AsyncRead::poll_read(client, cx, buf)
-         // }
          NamedPipedKind::ServerRead(server) => {
-            //server.poll_read(cx, buf)
             tokio::pin!(server);
             tokio::io::AsyncRead::poll_read(server, cx, buf)
 
          },
          NamedPipedKind::ClientRead(client) => {
-            // client.poll_read(cx, buf)
             tokio::pin!(client);
             tokio::io::AsyncRead::poll_read(client, cx, buf)
 
          },
          _ => unreachable!(),
       }
-
-      // let r = &mut self.read_half;
-      // tokio::pin!(r);
-      // tokio::io::AsyncRead::poll_read(r, cx, buf)
    }
 }
 
@@ -88,9 +50,6 @@ impl tokio::io::AsyncRead for IpcRead {
 #[allow(dead_code)]
 pub(crate) struct IpcWrite {
    config: Arc<Config>,
-   //write_half: tokio::io::WriteHalf<tokio::net::UnixStream>,
-   //write_half: tokio::io::WriteHalf<Channel>,
-
    write_half: NamedPipedKind,
 }
 
@@ -104,22 +63,16 @@ impl tokio::io::AsyncWrite for IpcWrite {
       let w = &mut self.write_half;
       match w {
          NamedPipedKind::ServerWrite(server) => {
-            //server.poll_read(cx, buf)
             tokio::pin!(server);
             tokio::io::AsyncWrite::poll_write(server, cx, buf)
 
          },
          NamedPipedKind::ClientWrite(client) => {
-            // client.poll_read(cx, buf)
             tokio::pin!(client);
             tokio::io::AsyncWrite::poll_write(client, cx, buf)
          },
          _ => unreachable!(),
       }
-
-      // let r = &mut self.write_half;
-      // tokio::pin!(r);
-      // tokio::io::AsyncWrite::poll_write(r, cx, buf)
    }
 
 
@@ -144,10 +97,6 @@ impl tokio::io::AsyncWrite for IpcWrite {
          },
          _ => unreachable!(),
       }
-
-      // let r = &mut self.write_half;
-      // tokio::pin!(r);
-      // tokio::io::AsyncWrite::poll_flush(r, cx)
    }
 
    fn poll_shutdown(
@@ -158,57 +107,38 @@ impl tokio::io::AsyncWrite for IpcWrite {
       let w = &mut self.write_half;
       match w {
          NamedPipedKind::ServerWrite(server) => {
-            //server.poll_read(cx, buf)
             tokio::pin!(server);
             tokio::io::AsyncWrite::poll_shutdown(server, cx)
 
          },
          NamedPipedKind::ClientWrite(client) => {
-            // client.poll_read(cx, buf)
             tokio::pin!(client);
             tokio::io::AsyncWrite::poll_shutdown(client, cx)
          },
          _ => unreachable!(),
       }
-
-      // let r = &mut self.write_half;
-      // tokio::pin!(r);
-      // tokio::io::AsyncWrite::poll_shutdown(r, cx)
    }
 }
 
 
-/// Create an IPC Client
+/// Create a NamedPipe Client
+/// Return its IPC halves
 pub(crate) async fn ipc_connect(
    config: Arc<Config>,
 ) -> LairResult<(IpcRead, IpcWrite)> {
-
-   let pipe_path = config.get_socket_path(); //.to_string_lossy().to_string();
-
-   // let socket = tokio::net::UnixStream::connect(config.get_socket_path())
-   //    .await
-   //    .map_err(|e| {
-   //       LairError::IpcClientConnectError(
-   //          config.get_socket_path().to_string_lossy().to_string(),
-   //          e.into(),
-   //       )
-   //    })?;
-   // let (read_half, write_half) = tokio::io::split(socket);
-
+   let pipe_path = config.get_socket_path();
+   trace!("*** win_ipc | ipc_connect() called with {:?}", pipe_path);
+   // Create Client
    let client = loop {
       match ClientOptions::new().open(pipe_path) {
          Ok(client) => break client,
          Err(e) if e.raw_os_error() == Some(winerror::ERROR_PIPE_BUSY as i32) => (),
-         Err(_e) => return Err(LairError::from("TODO sorry!")),//Err(e),
+         Err(e) => return Err(LairError::from(format!("NamedPipe IPC failed: {}", e))),
       }
-
       time::sleep(Duration::from_millis(50)).await;
    };
-
-   //let half = Arc::new(client.clone());
-
+   // Split and return client
    let (read_half, write_half) = tokio::io::split(client);
-
    Ok((
       IpcRead {
          config: config.clone(),
@@ -222,77 +152,47 @@ pub(crate) async fn ipc_connect(
 }
 
 
-
-
 #[allow(dead_code)]
 pub(crate) struct IpcServer {
    config: Arc<Config>,
-   //socket: tokio::net::UnixListener,
-   //server: Arc<Mutex<NamedPipeServer>>,
-
-   //handle: BoxFuture<'static, RawHandle>,
-   //handle: RawHandle,
+   server: Option<NamedPipeServer>,
 }
 
 impl IpcServer {
+   /// Create the initial NamedPipe server for given socket_path
    pub fn bind(config: Arc<Config>) -> LairResult<Self> {
-      //let _pipe_path = std::fs::remove_file(config.get_socket_path());
-
-      // let socket = tokio::net::UnixListener::bind(config.get_socket_path())
-      //    .map_err(LairError::other)?;
-
-      // const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-disconnect";
-      //
-      // let server =
-      //    //Arc::new(Mutex::new(
-      //    ServerOptions::new()
-      //    .create(PIPE_NAME)?
-      //    //))
-      //    ;
-      //
-      // let handle = server.as_raw_handle();
-
-      Ok(Self { config/*, handle*/})
+      let pipe_path = config.get_socket_path();
+      let _ = std::fs::remove_file(pipe_path);
+      let server = ServerOptions::new().create(pipe_path)?;
+      trace!("*** win_ipc | IpcServer::bind()    with {:?}", config.get_socket_path());
+      Ok(Self { config, server: Some(server) })
    }
 
-
+   /// Connect Client to Server
+   /// Return Server's IPC halves
    pub async fn accept(&mut self) -> LairResult<(IpcRead, IpcWrite)> {
-      //let (con, _) = self.server.accept().await.map_err(LairError::other)?;
-
-      // {
-      //    let server = self.server.lock().await;
-      //
-      //    let _connected = server.connect().await?;
-      //
-      //    server.readable().await?;
-      //    server.writable().await?;
-      // }
-
-      //let server = NamedPipeServer::from_raw_handle(self.handle).unwrap();
-
-      //const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-disconnect";
+      //let pipe_path: &str = r"\\.\pipe\tokio-named-pipe-disconnect";
       let pipe_path = self.config.get_socket_path();
-      let _ = std::fs::remove_file(pipe_path);
-
-      let server = ServerOptions::new().create(pipe_path)?;
-
-      server.readable().await?;
-      server.writable().await?;
-
+      trace!("*** win_ipc | IpcServer.accept()   with {:?}", pipe_path);
+      // Create new Server if initial one has already been taken
+      if self.server.is_none() {
+         self.server = Some(ServerOptions::new().create(pipe_path)?);
+      }
+      // Take and connect Server
+      let server = self.server.take().unwrap();
+      trace!("*** win_ipc | server_info = {:?}", server.info()?);
+      server.connect().await?;
+      // Split and return Server
       let (read_half, write_half) = tokio::io::split(server);
-
-      //let half = Arc::new(self.clone());
 
       Ok((
          IpcRead {
             config: self.config.clone(),
              read_half: NamedPipedKind::ServerRead(read_half),
-            //read_half: NamedPipedKind::Server(self.server.clone()),
          },
          IpcWrite {
             config: self.config.clone(),
             write_half: NamedPipedKind::ServerWrite(write_half),
-            //write_half: NamedPipedKind::Server(self.server.clone()),
          },
       ))
    }

--- a/crates/lair_keystore_client/Cargo.toml
+++ b/crates/lair_keystore_client/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 ghost_actor = "0.3.0-alpha.1"
 lair_keystore_api = { version = "=0.0.1-alpha.12", path = "../lair_keystore_api" }
 tempfile = "3"
-tokio = { version = "1.7.1", features = [ "full" ] }
+tokio = { version = "1.8.1", features = [ "full" ] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/lair_keystore_client/src/internal/run_lair_executable.rs
+++ b/crates/lair_keystore_client/src/internal/run_lair_executable.rs
@@ -19,8 +19,8 @@ pub async fn run_lair_executable(
         .map_err(LairError::other)?;
     let cmd = std::process::Command::new("lair-keystore")
         .env("LAIR_DIR", config.get_root_path())
-        .stdout(stdout)
-        .stderr(stderr)
+       .stdout(stdout)
+       .stderr(stderr)
         .stdin(std::process::Stdio::null())
         .spawn()
         .map_err(LairError::other)?;

--- a/crates/lair_keystore_client/src/internal/run_lair_executable.rs
+++ b/crates/lair_keystore_client/src/internal/run_lair_executable.rs
@@ -19,8 +19,8 @@ pub async fn run_lair_executable(
         .map_err(LairError::other)?;
     let cmd = std::process::Command::new("lair-keystore")
         .env("LAIR_DIR", config.get_root_path())
-       .stdout(stdout)
-       .stderr(stderr)
+        .stdout(stdout)
+        .stderr(stderr)
         .stdin(std::process::Stdio::null())
         .spawn()
         .map_err(LairError::other)?;


### PR DESCRIPTION
Used `tokio::named_pipe` to implement the Windows version of IPC.
`socket_path` had to be adjusted in Config for it to work properly.