### PR TITLE
add seed cipher util code

### DIFF
--- a/crates/hc_seed_bundle/src/seed_cipher.rs
+++ b/crates/hc_seed_bundle/src/seed_cipher.rs
@@ -1,1 +1,20 @@
 //! A module for seed bundle cipher related items
+
+use sodoken::{SodokenError, SodokenResult};
+
+#[allow(dead_code)]
+mod u8array;
+use u8array::*;
+
+#[allow(dead_code)]
+mod seed_bundle;
+#[allow(unused_imports)]
+use seed_bundle::*;
+
+#[allow(dead_code)]
+mod pw_utils;
+#[allow(unused_imports)]
+use pw_utils::*;
+
+mod pw_hash_limits;
+pub use pw_hash_limits::*;

--- a/crates/hc_seed_bundle/src/seed_cipher/pw_hash_limits.rs
+++ b/crates/hc_seed_bundle/src/seed_cipher/pw_hash_limits.rs
@@ -1,0 +1,67 @@
+/// Enum to specify limits (difficulty) for argon2id pwhashing algorithm.
+///
+/// Ops in this library don't take explicit limit parameters. Instead, they
+/// check the current context, if not set using the default "Moderate" limits.
+///
+/// To set the context for the scope of the "with_exec" callback:
+///
+/// ```rust
+/// # use hc_seed_bundle::*;
+/// let _my_result = PwHashLimits::Interactive.with_exec(|| {
+///   // execute my function that needs "interactive" limits
+/// });
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PwHashLimits {
+    /// low cpu/mem limits
+    Interactive,
+
+    /// middle cpu/mem limits (default)
+    Moderate,
+
+    /// high cpu/mem limits
+    Sensitive,
+}
+
+thread_local! {
+    static PWHASH_LIMITS: std::cell::RefCell<PwHashLimits> = std::cell::RefCell::new(PwHashLimits::Moderate);
+}
+
+impl PwHashLimits {
+    /// Get the current set limits
+    /// or the default "Moderate" limits if none are set by `with_exec()`.
+    pub fn current() -> Self {
+        PWHASH_LIMITS.with(|s| *s.borrow())
+    }
+
+    /// Execute a closure with these pwhash limits set.
+    pub fn with_exec<R, F>(self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        PWHASH_LIMITS.with(move |s| {
+            *s.borrow_mut() = self;
+            let res = f();
+            *s.borrow_mut() = PwHashLimits::Moderate;
+            res
+        })
+    }
+
+    /// translate into mem limit
+    pub(crate) fn as_mem_limit(&self) -> usize {
+        match self {
+            Self::Interactive => sodoken::argon2id::MEMLIMIT_INTERACTIVE,
+            Self::Moderate => sodoken::argon2id::MEMLIMIT_MODERATE,
+            Self::Sensitive => sodoken::argon2id::MEMLIMIT_SENSITIVE,
+        }
+    }
+
+    /// translate into cpu limit
+    pub(crate) fn as_ops_limit(&self) -> u64 {
+        match self {
+            Self::Interactive => sodoken::argon2id::OPSLIMIT_INTERACTIVE,
+            Self::Moderate => sodoken::argon2id::OPSLIMIT_MODERATE,
+            Self::Sensitive => sodoken::argon2id::OPSLIMIT_SENSITIVE,
+        }
+    }
+}

--- a/crates/hc_seed_bundle/src/seed_cipher/pw_utils.rs
+++ b/crates/hc_seed_bundle/src/seed_cipher/pw_utils.rs
@@ -1,0 +1,145 @@
+use super::*;
+
+/// For SeedCipherSecurityQuestions (and the "Locked" struct)
+/// we need to be able to translate three answers into a semi-deterministic
+/// passphrase. This process involves lower-casing, trimming, and concatonating.
+pub(crate) fn process_security_answers<A1, A2, A3>(
+    a1: A1,
+    a2: A2,
+    a3: A3,
+) -> SodokenResult<sodoken::BufRead>
+where
+    A1: Into<sodoken::BufRead> + 'static + Send,
+    A2: Into<sodoken::BufRead> + 'static + Send,
+    A3: Into<sodoken::BufRead> + 'static + Send,
+{
+    // first, get read-locks to all our input data
+    let a1 = a1.into();
+    let a1 = a1.read_lock();
+    let a2 = a2.into();
+    let a2 = a2.read_lock();
+    let a3 = a3.into();
+    let a3 = a3.read_lock();
+
+    // careful not to move any bytes out of protected memory
+    // convert to utf8 so we can use the rust trim / lcase functions.
+    let a1 = std::str::from_utf8(&*a1).map_err(SodokenError::other)?;
+    let a2 = std::str::from_utf8(&*a2).map_err(SodokenError::other)?;
+    let a3 = std::str::from_utf8(&*a3).map_err(SodokenError::other)?;
+
+    // trim
+    let a1 = a1.trim();
+    let a2 = a2.trim();
+    let a3 = a3.trim();
+
+    // get the utf8 bytes
+    let a1 = a1.as_bytes();
+    let a2 = a2.as_bytes();
+    let a3 = a3.as_bytes();
+
+    // create the output buffer
+    let out =
+        sodoken::BufWrite::new_mem_locked(a1.len() + a2.len() + a3.len())?;
+
+    {
+        // output buffer write lock
+        let mut out = out.write_lock();
+
+        // copy / concatonate the three answers
+        out[0..a1.len()].copy_from_slice(a1);
+        out[a1.len()..a1.len() + a2.len()].copy_from_slice(a2);
+        out[a1.len() + a2.len()..a1.len() + a2.len() + a3.len()]
+            .copy_from_slice(a3);
+
+        // we forced utf8 above, so safe to unwrap here
+        let out = std::str::from_utf8_mut(&mut *out).unwrap();
+
+        // this needs a mutable buffer, so we have to do this in out memory
+        out.make_ascii_lowercase();
+    }
+
+    // return the read-only concatonated passphrase
+    Ok(out.to_read())
+}
+
+/// Use the given passphrase to generate a deterministic secret with argon.
+/// Use that secret to secrestream encrypt the given seed.
+/// Return the argon salt, and the secretstream header and cipher.
+pub(crate) async fn pw_enc(
+    seed: sodoken::BufReadSized<32>,
+    passphrase: sodoken::BufRead,
+    limits: PwHashLimits,
+) -> SodokenResult<(
+    sodoken::BufReadSized<{ sodoken::argon2id::SALTBYTES }>,
+    sodoken::BufReadSized<24>,
+    sodoken::BufReadSized<49>,
+)> {
+    // generate a random salt
+    let salt = sodoken::BufWriteSized::new_no_lock();
+    sodoken::random::randombytes_buf(salt.clone()).await?;
+
+    // generate a secret using the passphrase with argon
+    let opslimit = limits.as_ops_limit();
+    let memlimit = limits.as_mem_limit();
+    let secret = sodoken::BufWriteSized::new_mem_locked()?;
+    sodoken::argon2id::hash(
+        secret.clone(),
+        passphrase,
+        salt.clone(),
+        opslimit,
+        memlimit,
+    )
+    .await?;
+
+    // initialize the secret stream encrypt item
+    use sodoken::secretstream_xchacha20poly1305::*;
+    let header = sodoken::BufWriteSized::new_no_lock();
+    let mut enc = SecretStreamEncrypt::new(secret, header.clone())?;
+
+    // encrypt the seed
+    let cipher = sodoken::BufWriteSized::new_no_lock();
+    enc.push_final(seed, <Option<sodoken::BufRead>>::None, cipher.clone())
+        .await?;
+
+    // Return the argon salt, and the secretstream header and cipher.
+    Ok((
+        salt.to_read_sized(),
+        header.to_read_sized(),
+        cipher.to_read_sized(),
+    ))
+}
+
+/// Use the given passphrase, salt, and limits to generate a deterministic
+/// secret with argon.
+/// Use the secret to decrypt the given secretstream header and cipher into
+/// a 32 byte secret seed.
+/// Return that seed.
+pub(crate) async fn pw_dec(
+    passphrase: sodoken::BufRead,
+    salt: sodoken::BufReadSized<{ sodoken::argon2id::SALTBYTES }>,
+    mem_limit: usize,
+    ops_limit: u64,
+    header: sodoken::BufReadSized<24>,
+    cipher: sodoken::BufReadSized<49>,
+) -> SodokenResult<sodoken::BufReadSized<32>> {
+    // generate the argon secret
+    let secret = sodoken::BufWriteSized::new_mem_locked()?;
+    sodoken::argon2id::hash(
+        secret.clone(),
+        passphrase,
+        salt,
+        ops_limit,
+        mem_limit,
+    )
+    .await?;
+
+    // decrypt the seed
+    use sodoken::secretstream_xchacha20poly1305::*;
+    let mut dec = SecretStreamDecrypt::new(secret, header)?;
+    let seed = sodoken::BufWriteSized::new_mem_locked()?;
+    dec.pull(cipher, <Option<sodoken::BufRead>>::None, seed.clone())
+        .await?;
+
+    // return the seed
+    Ok(seed.to_read_sized())
+}

--- a/crates/hc_seed_bundle/src/seed_cipher/pw_utils.rs
+++ b/crates/hc_seed_bundle/src/seed_cipher/pw_utils.rs
@@ -2,7 +2,7 @@ use super::*;
 
 /// For SeedCipherSecurityQuestions (and the "Locked" struct)
 /// we need to be able to translate three answers into a semi-deterministic
-/// passphrase. This process involves lower-casing, trimming, and concatonating.
+/// passphrase. This process involves lower-casing, trimming, and concatenating.
 pub(crate) fn process_security_answers<A1, A2, A3>(
     a1: A1,
     a2: A2,
@@ -63,7 +63,7 @@ where
 }
 
 /// Use the given passphrase to generate a deterministic secret with argon.
-/// Use that secret to secrestream encrypt the given seed.
+/// Use that secret to secretstream encrypt the given seed.
 /// Return the argon salt, and the secretstream header and cipher.
 pub(crate) async fn pw_enc(
     seed: sodoken::BufReadSized<32>,

--- a/crates/hc_seed_bundle/src/seed_cipher/seed_bundle.rs
+++ b/crates/hc_seed_bundle/src/seed_cipher/seed_bundle.rs
@@ -1,0 +1,239 @@
+//! We want both ergonomic structs on the rust side, and compact encoding
+//! on the encoded binary side. The hcSeedBundle encoding spec uses msgpack
+//! arrays to compact the encoding. These structs translate between that
+//! compact encoding and the more ergonomic rust data structures.
+
+use super::*;
+
+/// The more ergonomic rust structure of an (encrypted) seed bundle.
+#[derive(Debug)]
+pub(crate) struct SeedBundle {
+    /// The list of ciphers that will allow decrypting the seed.
+    pub cipher_list: Box<[SeedCipher]>,
+
+    /// The encoded app_data associated with this bundle.
+    pub app_data: Box<[u8]>,
+}
+
+/// A helper struct to serialize a seed bundle in the compact msgpack array fmt.
+#[derive(serde::Serialize)]
+struct ISer<'lt>(
+    &'lt str,
+    &'lt [SeedCipher],
+    #[serde(with = "serde_bytes")] &'lt [u8],
+);
+
+impl serde::Serialize for SeedBundle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        ISer("hcsb0", &self.cipher_list, &self.app_data).serialize(serializer)
+    }
+}
+
+/// A helper struct for deserializing a seed bundle from the compact msgpack fmt
+#[derive(serde::Deserialize)]
+struct IDes<'lt>(
+    &'lt str,
+    Box<[SeedCipher]>,
+    #[serde(with = "serde_bytes")] Box<[u8]>,
+);
+
+impl<'de> serde::Deserialize<'de> for SeedBundle {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let dec: IDes<'de> = serde::Deserialize::deserialize(deserializer)?;
+        if dec.0 != "hcsb0" {
+            return Err(serde::de::Error::custom(format!(
+                "unsupported bundle version: {}",
+                dec.0
+            )));
+        }
+        Ok(SeedBundle {
+            cipher_list: dec.1,
+            app_data: dec.2,
+        })
+    }
+}
+
+/// The more ergonomic rust structure of an (encrypted) seed cipher.
+#[derive(Debug)]
+pub(crate) enum SeedCipher {
+    /// PwHash type seed cipher
+    PwHash {
+        /// argon salt
+        salt: U8Array<16>,
+
+        /// argon mem limit
+        mem_limit: u32,
+
+        /// argon ops limit
+        ops_limit: u32,
+
+        /// secretstream header
+        header: U8Array<24>,
+
+        /// secretstream cipher
+        cipher: U8Array<49>,
+    },
+    /// Security Questions type seed cipher
+    SecurityQuestions {
+        /// argon salt
+        salt: U8Array<16>,
+
+        /// argon mem limit
+        mem_limit: u32,
+
+        /// argon ops limit
+        ops_limit: u32,
+
+        /// the three security questions to ask the user
+        question_list: (String, String, String),
+
+        /// secretstream header
+        header: U8Array<24>,
+
+        /// secretstream cipher
+        cipher: U8Array<49>,
+    },
+}
+
+impl serde::Serialize for SeedCipher {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // serialize into the more compact msgpack array format
+        match self {
+            Self::PwHash {
+                salt,
+                mem_limit,
+                ops_limit,
+                header,
+                cipher,
+            } => ("pw", salt, mem_limit, ops_limit, header, cipher)
+                .serialize(serializer),
+            Self::SecurityQuestions {
+                salt,
+                mem_limit,
+                ops_limit,
+                question_list,
+                header,
+                cipher,
+            } => (
+                "qa",
+                salt,
+                mem_limit,
+                ops_limit,
+                &question_list.0,
+                &question_list.1,
+                &question_list.2,
+                header,
+                cipher,
+            )
+                .serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SeedCipher {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // deserializing the compact msgpack array format is a little more
+        // complicated. We need to implement a visitor that can change
+        // behavior after reading the first "type" marker at the beginning
+        // of the array
+
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = SeedCipher;
+
+            fn expecting(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::fmt::Result {
+                write!(f, "SeedCipher array")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                // DRY out the following by macroizing the redundant
+                // next_element boilerplate.
+                macro_rules! next_elem {
+                    ($t:ty, $s:ident, $e:literal) => {{
+                        let out: $t = match $s.next_element() {
+                            Ok(Some(t)) => t,
+                            _ => return Err(serde::de::Error::custom($e)),
+                        };
+                        out
+                    }};
+                }
+
+                // read the first element of the array, the "type" marker
+                let type_name =
+                    next_elem!(&'de str, seq, "expected cipher type_name");
+
+                // switch based on that type marker
+                match type_name {
+                    "pw" => {
+                        let salt =
+                            next_elem!(U8Array<16>, seq, "expected salt");
+                        let mem_limit =
+                            next_elem!(u32, seq, "expected mem_limit");
+                        let ops_limit =
+                            next_elem!(u32, seq, "expected ops_limit");
+                        let header =
+                            next_elem!(U8Array<24>, seq, "expected header");
+                        let cipher =
+                            next_elem!(U8Array<49>, seq, "expected cipher");
+                        Ok(SeedCipher::PwHash {
+                            salt,
+                            mem_limit,
+                            ops_limit,
+                            header,
+                            cipher,
+                        })
+                    }
+                    "qa" => {
+                        let salt =
+                            next_elem!(U8Array<16>, seq, "expected salt");
+                        let mem_limit =
+                            next_elem!(u32, seq, "expected mem_limit");
+                        let ops_limit =
+                            next_elem!(u32, seq, "expected ops_limit");
+                        let q1 = next_elem!(String, seq, "expected question 1");
+                        let q2 = next_elem!(String, seq, "expected question 2");
+                        let q3 = next_elem!(String, seq, "expected question 3");
+                        let header =
+                            next_elem!(U8Array<24>, seq, "expected header");
+                        let cipher =
+                            next_elem!(U8Array<49>, seq, "expected cipher");
+                        Ok(SeedCipher::SecurityQuestions {
+                            salt,
+                            mem_limit,
+                            ops_limit,
+                            question_list: (q1, q2, q3),
+                            header,
+                            cipher,
+                        })
+                    }
+                    oth => {
+                        return Err(serde::de::Error::custom(format!(
+                            "unsupported cipher type: {}",
+                            oth
+                        )))
+                    }
+                }
+            }
+        }
+
+        deserializer.deserialize_seq(V)
+    }
+}

--- a/crates/hc_seed_bundle/src/seed_cipher/u8array.rs
+++ b/crates/hc_seed_bundle/src/seed_cipher/u8array.rs
@@ -1,0 +1,108 @@
+use std::ops::{Deref, DerefMut};
+
+/// A fixed sized byte array with all the translation and serialization
+/// support we need for working with SeedBundles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct U8Array<const N: usize>(pub [u8; N]);
+
+impl<const N: usize> From<U8Array<N>> for sodoken::BufReadSized<N> {
+    fn from(o: U8Array<N>) -> Self {
+        o.0.into()
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for U8Array<N> {
+    fn from(o: [u8; N]) -> Self {
+        Self(o)
+    }
+}
+
+impl<const N: usize> From<sodoken::BufReadSized<N>> for U8Array<N> {
+    fn from(o: sodoken::BufReadSized<N>) -> Self {
+        (*o.read_lock_sized()).into()
+    }
+}
+
+impl<const N: usize> From<Box<[u8]>> for U8Array<N> {
+    fn from(o: Box<[u8]>) -> Self {
+        // we need to runtime panic when loading from unsized sources
+        assert_eq!(o.len(), N);
+        let mut out = [0; N];
+        out.copy_from_slice(&o[0..N]);
+        out.into()
+    }
+}
+
+impl<const N: usize> From<Vec<u8>> for U8Array<N> {
+    fn from(o: Vec<u8>) -> Self {
+        o.into_boxed_slice().into()
+    }
+}
+
+impl<const N: usize> Deref for U8Array<N> {
+    type Target = [u8; N];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const N: usize> DerefMut for U8Array<N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<const N: usize> AsRef<[u8; N]> for U8Array<N> {
+    fn as_ref(&self) -> &[u8; N] {
+        self.deref()
+    }
+}
+
+impl<const N: usize> AsMut<[u8; N]> for U8Array<N> {
+    fn as_mut(&mut self) -> &mut [u8; N] {
+        self.deref_mut()
+    }
+}
+
+impl<const N: usize> serde::Serialize for U8Array<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // serialize directly as bytes
+        serializer.serialize_bytes(self.deref())
+    }
+}
+
+impl<'de, const N: usize> serde::Deserialize<'de> for U8Array<N> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Unfortunately, by default javascript encodes Uint8Arrays as
+        // "ext" fields. We could fix this in our library, but if someone
+        // else writes one they may run into this problem. Instead, we
+        // can be forgiving and accept "ext" entries as binary data.
+        let v: rmpv::Value = serde::Deserialize::deserialize(deserializer)?;
+        let v = match v {
+            rmpv::Value::Binary(b) => b,
+            rmpv::Value::Ext(_, b) => b,
+            _ => {
+                return Err(serde::de::Error::custom(
+                    "invalid type, expected bytes",
+                ))
+            }
+        };
+        if v.len() != N {
+            return Err(serde::de::Error::custom(format!(
+                "expected {} bytes, got {} bytes",
+                N,
+                v.len()
+            )));
+        }
+        let mut out = [0; N];
+        out.copy_from_slice(&v[0..N]);
+        Ok(Self(out))
+    }
+}


### PR DESCRIPTION
DEPENDS ON https://github.com/holochain/lair/pull/46

- adds utilites that make writing the seed_cipher code possible
  - `pw_hash_limits` - argon2id memory and ops limit controls
  - `pw_utils` - password hashing utilities
  - `seed_bundle` - serialization code to translate between ergonomic rust structs and compact msgpack array format
  - `u8array` - fixed-size array newtype with lots of ergonomic from impls