### PR TITLE
[new-lair-4] lair store abstraction + memory implementation

### DIFF
--- a/crates/lair_keystore_api/src/config.rs
+++ b/crates/lair_keystore_api/src/config.rs
@@ -1,0 +1,254 @@
+//! Lair Configuration Types
+
+use crate::prelude::*;
+use std::future::Future;
+use std::sync::Arc;
+
+/// Config used by lair servers.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct LairServerConfigInner {
+    /// The connection url for communications between server / client.
+    /// - `unix:///path/to/unix/socket?k=Yada`
+    /// - `named_pipe:\\.\pipe\my_pipe_name?k=Yada`
+    /// - `tcp://127.0.0.1:12345?k=Yada`
+    pub connection_url: url::Url,
+
+    /// The pid file for managing a running lair-keystore process
+    pub pid_file: std::path::PathBuf,
+
+    /// The sqlcipher store file for persisting secrets
+    pub store_file: std::path::PathBuf,
+
+    /// salt for decrypting runtime data
+    pub runtime_secrets_salt: BinDataSized<16>,
+
+    /// argon2id mem_limit for decrypting runtime data
+    pub runtime_secrets_mem_limit: u32,
+
+    /// argon2id ops_limit for decrypting runtime data
+    pub runtime_secrets_ops_limit: u32,
+
+    /// the runtime context key secret
+    pub runtime_secrets_context_key: SecretDataSized<32, 49>,
+
+    /// the server identity signature keypair seed
+    pub runtime_secrets_sign_seed: SecretDataSized<32, 49>,
+}
+
+impl std::fmt::Display for LairServerConfigInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = serde_yaml::to_string(&self).map_err(|_| std::fmt::Error)?;
+        f.write_str(&s)
+    }
+}
+
+impl LairServerConfigInner {
+    /// decode yaml bytes into a config struct
+    pub fn from_bytes(bytes: &[u8]) -> LairResult<Self> {
+        serde_yaml::from_slice(bytes).map_err(one_err::OneErr::new)
+    }
+
+    /// Construct a new default lair server config instance.
+    /// Respects hc_seed_bundle::PwHashLimits.
+    pub fn new<P>(
+        root_path: P,
+        passphrase: sodoken::BufRead,
+    ) -> impl Future<Output = LairResult<Self>> + 'static + Send
+    where
+        P: AsRef<std::path::Path>,
+    {
+        let root_path = root_path.as_ref().to_owned();
+        let limits = hc_seed_bundle::PwHashLimits::current();
+        async move {
+            // default pid_file name is '[root_path]/pid_file'
+            let mut pid_file = root_path.clone();
+            pid_file.push("pid_file");
+
+            // default store_file name is '[root_path]/store_file'
+            let mut store_file = root_path.clone();
+            store_file.push("store_file");
+
+            // generate a random salt for the pwhash
+            let salt = <sodoken::BufWriteSized<16>>::new_no_lock();
+            sodoken::random::bytes_buf(salt.clone()).await?;
+
+            // pull the captured argon2id limits
+            let ops_limit = limits.as_ops_limit();
+            let mem_limit = limits.as_mem_limit();
+
+            // generate an argon2id pre_secret from the passphrase
+            let pre_secret = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+            sodoken::hash::argon2id::hash(
+                pre_secret.clone(),
+                passphrase,
+                salt.clone(),
+                ops_limit,
+                mem_limit,
+            )
+            .await?;
+
+            // derive our context secret
+            // this will be used to encrypt the context_key
+            let ctx_secret = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+            sodoken::kdf::derive_from_key(
+                ctx_secret.clone(),
+                42,
+                *b"CtxSecKy",
+                pre_secret.clone(),
+            )?;
+
+            // derive our signature secret
+            // this will be used to encrypt the signature seed
+            let sig_secret = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+            sodoken::kdf::derive_from_key(
+                sig_secret.clone(),
+                142,
+                *b"SigSecKy",
+                pre_secret,
+            )?;
+
+            // the context key is used to encrypt our store_file
+            let context_key = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+            sodoken::random::bytes_buf(context_key.clone()).await?;
+
+            // the sign seed derives our signature keypair
+            // which allows us to authenticate server identity
+            let sign_seed = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+            sodoken::random::bytes_buf(sign_seed.clone()).await?;
+
+            // server identity verification signature keypair
+            let sign_pk = <sodoken::BufWriteSized<32>>::new_no_lock();
+            let sign_sk = <sodoken::BufWriteSized<64>>::new_mem_locked()?;
+            sodoken::sign::seed_keypair(
+                sign_pk.clone(),
+                sign_sk,
+                sign_seed.clone(),
+            )
+            .await?;
+
+            // lock the context key
+            let context_key = SecretDataSized::encrypt(
+                ctx_secret.to_read_sized(),
+                context_key.to_read_sized(),
+            )
+            .await?;
+
+            // lock the signature seed
+            let sign_seed = SecretDataSized::encrypt(
+                sig_secret.to_read_sized(),
+                sign_seed.to_read_sized(),
+            )
+            .await?;
+
+            // get the signature public key bytes for encoding in the url
+            let sign_pk: BinDataSized<32> =
+                sign_pk.try_unwrap_sized().unwrap().into();
+
+            // on windows, we default to using "named pipes"
+            #[cfg(windows)]
+            let connection_url = {
+                let id = nanoid::nanoid!();
+                url::Url::parse(&format!(
+                    "named-pipe:\\\\.\\pipe\\{}?k={}",
+                    id, sign_pk
+                ))
+                .unwrap()
+            };
+
+            // on not-windows, we default to using unix domain sockets
+            #[cfg(not(windows))]
+            let connection_url = {
+                let mut con_path = root_path.clone();
+                con_path.push("socket");
+                url::Url::parse(&format!(
+                    "unix://{}?k={}",
+                    con_path.to_str().unwrap(),
+                    sign_pk
+                ))
+                .unwrap()
+            };
+
+            // put together the full server config struct
+            let config = LairServerConfigInner {
+                connection_url,
+                pid_file,
+                store_file,
+                runtime_secrets_salt: salt.try_unwrap_sized().unwrap().into(),
+                runtime_secrets_mem_limit: mem_limit,
+                runtime_secrets_ops_limit: ops_limit,
+                runtime_secrets_context_key: context_key,
+                runtime_secrets_sign_seed: sign_seed,
+            };
+
+            Ok(config)
+        }
+    }
+
+    /// Get the connection "scheme". i.e. "unix", "named-pipe", or "tcp".
+    pub fn get_connection_scheme(&self) -> &str {
+        self.connection_url.scheme()
+    }
+
+    /// Get the connection "path". This could have different meanings
+    /// depending on if we are a unix domain socket or named pipe, etc.
+    pub fn get_connection_path(&self) -> &str {
+        self.connection_url.path()
+    }
+
+    /// Get the server pub key BinDataSized<32> bytes from the connectionUrl
+    pub fn get_server_pub_key(&self) -> LairResult<BinDataSized<32>> {
+        get_server_pub_key_from_connection_url(&self.connection_url)
+    }
+}
+
+/// extract a server_pub_key from a connection_url
+pub fn get_server_pub_key_from_connection_url(
+    url: &url::Url,
+) -> LairResult<BinDataSized<32>> {
+    for (k, v) in url.query_pairs() {
+        if k == "k" {
+            let tmp =
+                base64::decode_config(v.as_bytes(), base64::URL_SAFE_NO_PAD)
+                    .map_err(one_err::OneErr::new)?;
+            if tmp.len() != 32 {
+                return Err(format!(
+                    "invalid server_pub_key len, expected 32, got {}",
+                    tmp.len()
+                )
+                .into());
+            }
+            let mut out = [0; 32];
+            out.copy_from_slice(&tmp);
+            return Ok(out.into());
+        }
+    }
+    Err("no server_pub_key on connection_url".into())
+}
+
+/// Configuration for running a lair-keystore server instance.
+pub type LairServerConfig = Arc<LairServerConfigInner>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_config_yaml() {
+        let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
+        let srv = hc_seed_bundle::PwHashLimits::Interactive
+            .with_exec(|| {
+                LairServerConfigInner::new("/tmp/my/path", passphrase)
+            })
+            .await
+            .unwrap();
+        println!("-- server config start --");
+        println!("{}", serde_yaml::to_string(&srv).unwrap());
+        println!("-- server config end --");
+        assert_eq!(
+            std::path::PathBuf::from("/tmp/my/path").as_path(),
+            srv.pid_file.parent().unwrap(),
+        );
+    }
+}

--- a/crates/lair_keystore_api/src/encoding_types.rs
+++ b/crates/lair_keystore_api/src/encoding_types.rs
@@ -255,3 +255,12 @@ impl<const M: usize, const C: usize> SecretDataSized<M, C> {
         Ok(out.to_read_sized())
     }
 }
+
+/// ed25519 signature public key derived from this seed.
+pub type Ed25519PubKey = BinDataSized<32>;
+
+/// ed25519 signature bytes.
+pub type Ed25519Signature = BinDataSized<64>;
+
+/// x25519 encryption public key derived from this seed.
+pub type X25519PubKey = BinDataSized<32>;

--- a/crates/lair_keystore_api/src/lair_store.rs
+++ b/crates/lair_keystore_api/src/lair_store.rs
@@ -1,0 +1,420 @@
+//! lair persistance
+
+use crate::prelude::*;
+use futures::future::BoxFuture;
+use std::future::Future;
+use std::sync::Arc;
+
+/// Helper traits for store types - you probably don't need these unless
+/// you are implementing new lair core instance logic.
+pub mod traits {
+    use super::*;
+
+    /// Defines a lair storage mechanism.
+    pub trait AsLairStore: 'static + Send + Sync {
+        /// Return the context key for both encryption and decryption
+        /// of secret data within the store that is NOT deep_locked.
+        fn get_bidi_ctx_key(&self) -> sodoken::BufReadSized<32>;
+
+        /// List the entries tracked by the lair store.
+        fn list_entries(
+            &self,
+        ) -> BoxFuture<'static, LairResult<Vec<LairEntryInfo>>>;
+
+        /// Write a new entry to the lair store.
+        fn write_entry(
+            &self,
+            entry: LairEntry,
+        ) -> BoxFuture<'static, LairResult<()>>;
+
+        /// Get an entry from the lair store by tag.
+        fn get_entry_by_tag(
+            &self,
+            tag: Arc<str>,
+        ) -> BoxFuture<'static, LairResult<LairEntry>>;
+
+        /// Get an entry from the lair store by ed25519 pub key.
+        fn get_entry_by_ed25519_pub_key(
+            &self,
+            ed25519_pub_key: Ed25519PubKey,
+        ) -> BoxFuture<'static, LairResult<LairEntry>>;
+    }
+
+    /// Defines a factory that produces lair storage mechanism instances.
+    pub trait AsLairStoreFactory: 'static + Send + Sync {
+        /// Open a store connection with given config / passphrase.
+        fn connect_to_store(
+            &self,
+            unlock_secret: sodoken::BufReadSized<32>,
+        ) -> BoxFuture<'static, LairResult<LairStore>>;
+    }
+}
+use traits::*;
+
+/// Public information associated with a given seed
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SeedInfo {
+    /// The ed25519 signature public key derived from this seed.
+    pub ed25519_pub_key: Ed25519PubKey,
+
+    /// The x25519 encryption public key derived from this seed.
+    pub x25519_pub_key: X25519PubKey,
+}
+
+/// The 32 byte blake2b digest of the der encoded tls certificate.
+pub type CertDigest = BinDataSized<32>;
+
+/// Public information associated with a given tls certificate.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CertInfo {
+    /// The random sni that was generated for this certificate.
+    pub sni: Arc<str>,
+
+    /// The 32 byte blake2b digest of the der encoded tls certificate.
+    pub digest: CertDigest,
+
+    /// The der-encoded tls certificate bytes.
+    pub cert: BinData,
+}
+
+/// The Type and Tag of this lair entry.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+#[non_exhaustive]
+pub enum LairEntryInfo {
+    /// This entry is type 'Seed' (see LairEntryInner).
+    Seed {
+        /// user-supplied tag for this seed
+        tag: Arc<str>,
+        /// the seed info associated with this seed
+        seed_info: SeedInfo,
+    },
+
+    /// This entry is type 'DeepLockedSeed' (see LairEntryInner).
+    DeepLockedSeed {
+        /// user-supplied tag for this seed
+        tag: Arc<str>,
+        /// the seed info associated with this seed
+        seed_info: SeedInfo,
+    },
+
+    /// This entry is type 'TlsCert' (see LairEntryInner).
+    WkaTlsCert {
+        /// user-supplied tag for this seed
+        tag: Arc<str>,
+        /// the certificate info
+        cert_info: CertInfo,
+    },
+}
+
+/// The raw lair entry inner types that can be stored.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+#[non_exhaustive]
+pub enum LairEntryInner {
+    /// This seed can be
+    /// - derived
+    /// - used for ed25519 signatures
+    /// - used for x25519 encryption
+    /// The secretstream seed uses the base passphrase-derived secret
+    /// for decryption.
+    Seed {
+        /// user-supplied tag for this seed
+        tag: Arc<str>,
+        /// the seed info associated with this seed
+        seed_info: SeedInfo,
+        /// the actual seed, encrypted with context key
+        seed: SecretDataSized<32, 49>,
+    },
+
+    /// As 'Seed' but requires an additional access-time passphrase to use
+    DeepLockedSeed {
+        /// user-supplied tag for this seed
+        tag: Arc<str>,
+        /// the seed info associated with this seed
+        seed_info: SeedInfo,
+        /// salt for argon2id encrypted seed
+        salt: BinDataSized<16>,
+        /// argon2id ops limit used when encrypting this seed
+        ops_limit: u32,
+        /// argon2id mem limit used when encrypting this seed
+        mem_limit: u32,
+        /// the actual seed, encrypted with deep passphrase
+        seed: SecretDataSized<32, 49>,
+    },
+
+    /// This tls cert and private key can be used to establish tls cryptography
+    /// The secretstream priv_key uses the base passphrase-derived secret
+    /// for decryption.
+    WkaTlsCert {
+        /// user-supplied tag for this tls certificate
+        tag: Arc<str>,
+        /// the certificate info
+        cert_info: CertInfo,
+        /// the certificate private key, encrypted with context key
+        priv_key: SecretData,
+    },
+}
+
+impl LairEntryInner {
+    /// encode this LairEntry as bytes
+    pub fn encode(&self) -> LairResult<Box<[u8]>> {
+        use serde::Serialize;
+        let mut se = rmp_serde::encode::Serializer::new(Vec::new())
+            .with_struct_map()
+            .with_string_variants();
+        self.serialize(&mut se).map_err(one_err::OneErr::new)?;
+        Ok(se.into_inner().into_boxed_slice())
+    }
+
+    /// decode a LairEntry from bytes
+    pub fn decode(bytes: &[u8]) -> LairResult<LairEntryInner> {
+        let item: LairEntryInner =
+            rmp_serde::from_read(bytes).map_err(one_err::OneErr::new)?;
+        Ok(item)
+    }
+
+    /// get the tag associated with this entry
+    pub fn tag(&self) -> Arc<str> {
+        match self {
+            Self::Seed { tag, .. } => tag.clone(),
+            Self::DeepLockedSeed { tag, .. } => tag.clone(),
+            Self::WkaTlsCert { tag, .. } => tag.clone(),
+        }
+    }
+}
+
+/// The LairEntry enum.
+pub type LairEntry = Arc<LairEntryInner>;
+
+/// Lair store concrete struct
+#[derive(Clone)]
+pub struct LairStore(pub Arc<dyn AsLairStore>);
+
+impl LairStore {
+    /// Return the context key for both encryption and decryption
+    /// of secret data within the store that is NOT deep_locked.
+    pub fn get_bidi_ctx_key(&self) -> sodoken::BufReadSized<32> {
+        AsLairStore::get_bidi_ctx_key(&*self.0)
+    }
+
+    /// Generate a new cryptographically secure random seed,
+    /// and associate it with the given tag, returning the
+    /// seed_info derived from the generated seed.
+    pub fn new_seed(
+        &self,
+        tag: Arc<str>,
+    ) -> impl Future<Output = LairResult<SeedInfo>> + 'static + Send {
+        let inner = self.0.clone();
+        async move {
+            // generate a new random seed
+            let seed = sodoken::BufWriteSized::new_mem_locked()?;
+            sodoken::random::bytes_buf(seed.clone()).await?;
+
+            // derive the ed25519 signature keypair from this seed
+            let ed_pk = sodoken::BufWriteSized::new_no_lock();
+            let ed_sk = sodoken::BufWriteSized::new_mem_locked()?;
+            sodoken::sign::seed_keypair(ed_pk.clone(), ed_sk, seed.clone())
+                .await?;
+
+            // derive the x25519 encryption keypair from this seed
+            let x_pk = sodoken::BufWriteSized::new_no_lock();
+            let x_sk = sodoken::BufWriteSized::new_mem_locked()?;
+            sodoken::sealed_box::curve25519xchacha20poly1305::seed_keypair(
+                x_pk.clone(),
+                x_sk,
+                seed.clone(),
+            )
+            .await?;
+
+            // encrypt the seed with our bidi context key
+            let key = inner.get_bidi_ctx_key();
+            let seed =
+                SecretDataSized::encrypt(key, seed.to_read_sized()).await?;
+
+            // populate our seed info with the derived public keys
+            let seed_info = SeedInfo {
+                ed25519_pub_key: ed_pk.try_unwrap_sized().unwrap().into(),
+                x25519_pub_key: x_pk.try_unwrap_sized().unwrap().into(),
+            };
+
+            // construct the entry for the keystore
+            let entry = LairEntryInner::Seed {
+                tag,
+                seed_info: seed_info.clone(),
+                seed,
+            };
+
+            // write the entry to the store
+            inner.write_entry(Arc::new(entry)).await?;
+
+            // return the seed info
+            Ok(seed_info)
+        }
+    }
+
+    /// Generate a new cryptographically secure random seed,
+    /// and associate it with the given tag, returning the
+    /// seed_info derived from the generated seed.
+    /// This seed is deep_locked, meaning it needs an additional
+    /// runtime passphrase to be decrypted / used.
+    pub fn new_deep_locked_seed(
+        &self,
+        tag: Arc<str>,
+        ops_limit: u32,
+        mem_limit: u32,
+        deep_lock_passphrase: sodoken::BufRead,
+    ) -> impl Future<Output = LairResult<SeedInfo>> + 'static + Send {
+        let inner = self.0.clone();
+        async move {
+            // generate a new random seed
+            let seed = sodoken::BufWriteSized::new_mem_locked()?;
+            sodoken::random::bytes_buf(seed.clone()).await?;
+
+            // derive the ed25519 signature keypair from this seed
+            let ed_pk = sodoken::BufWriteSized::new_no_lock();
+            let ed_sk = sodoken::BufWriteSized::new_mem_locked()?;
+            sodoken::sign::seed_keypair(ed_pk.clone(), ed_sk, seed.clone())
+                .await?;
+
+            // derive the x25519 encryption keypair from this seed
+            let x_pk = sodoken::BufWriteSized::new_no_lock();
+            let x_sk = sodoken::BufWriteSized::new_mem_locked()?;
+            sodoken::sealed_box::curve25519xchacha20poly1305::seed_keypair(
+                x_pk.clone(),
+                x_sk,
+                seed.clone(),
+            )
+            .await?;
+
+            // generate the salt for the pwhash deep locking
+            let salt = <sodoken::BufWriteSized<16>>::new_no_lock();
+            sodoken::random::bytes_buf(salt.clone()).await?;
+
+            // generate the deep lock key from the passphrase
+            let key = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+            sodoken::hash::argon2id::hash(
+                key.clone(),
+                deep_lock_passphrase,
+                salt.clone(),
+                ops_limit,
+                mem_limit,
+            )
+            .await?;
+
+            // encrypt the seed with the deep lock key
+            let seed = SecretDataSized::encrypt(
+                key.to_read_sized(),
+                seed.to_read_sized(),
+            )
+            .await?;
+
+            // populate our seed info with the derived public keys
+            let seed_info = SeedInfo {
+                ed25519_pub_key: ed_pk.try_unwrap_sized().unwrap().into(),
+                x25519_pub_key: x_pk.try_unwrap_sized().unwrap().into(),
+            };
+
+            // construct the entry for the keystore
+            let entry = LairEntryInner::DeepLockedSeed {
+                tag,
+                seed_info: seed_info.clone(),
+                salt: salt.try_unwrap_sized().unwrap().into(),
+                ops_limit,
+                mem_limit,
+                seed,
+            };
+
+            // write the entry to the store
+            inner.write_entry(Arc::new(entry)).await?;
+
+            // return the seed info
+            Ok(seed_info)
+        }
+    }
+
+    /// Generate a new cryptographically secure random wka tls cert,
+    /// and associate it with the given tag, returning the
+    /// cert_info derived from the generated cert.
+    pub fn new_wka_tls_cert(
+        &self,
+        tag: Arc<str>,
+    ) -> impl Future<Output = LairResult<CertInfo>> + 'static + Send {
+        let inner = self.0.clone();
+        async move {
+            use crate::internal::tls::*;
+
+            // generate the random well-known-authority signed certificate.
+            let TlsCertGenResult {
+                sni,
+                priv_key,
+                cert,
+                digest,
+            } = tls_cert_self_signed_new().await?;
+
+            // encrypt the private key with our context secret
+            let key = inner.get_bidi_ctx_key();
+            let priv_key = SecretData::encrypt(key, priv_key).await?;
+
+            // populate the certificate info
+            let cert_info = CertInfo {
+                sni,
+                digest: digest.into(),
+                cert: cert.into(),
+            };
+
+            // construct the entry for the keystore
+            let entry = LairEntryInner::WkaTlsCert {
+                tag,
+                cert_info: cert_info.clone(),
+                priv_key,
+            };
+
+            // write the entry to the store
+            inner.write_entry(Arc::new(entry)).await?;
+
+            // return the cert info
+            Ok(cert_info)
+        }
+    }
+
+    /// List the entries tracked by the lair store.
+    pub fn list_entries(
+        &self,
+    ) -> impl Future<Output = LairResult<Vec<LairEntryInfo>>> + 'static + Send
+    {
+        AsLairStore::list_entries(&*self.0)
+    }
+
+    /// Get an entry from the lair store by tag.
+    pub fn get_entry_by_tag(
+        &self,
+        tag: Arc<str>,
+    ) -> impl Future<Output = LairResult<LairEntry>> + 'static + Send {
+        AsLairStore::get_entry_by_tag(&*self.0, tag)
+    }
+
+    /// Get an entry from the lair store by ed25519 pub key.
+    pub fn get_entry_by_ed25519_pub_key(
+        &self,
+        ed25519_pub_key: Ed25519PubKey,
+    ) -> impl Future<Output = LairResult<LairEntry>> + 'static + Send {
+        AsLairStore::get_entry_by_ed25519_pub_key(&*self.0, ed25519_pub_key)
+    }
+}
+
+/// Lair store factory concrete struct
+#[derive(Clone)]
+pub struct LairStoreFactory(pub Arc<dyn AsLairStoreFactory>);
+
+impl LairStoreFactory {
+    /// Connect to an existing store with the given unlock_secret.
+    pub fn connect_to_store(
+        &self,
+        unlock_secret: sodoken::BufReadSized<32>,
+    ) -> impl Future<Output = LairResult<LairStore>> + 'static + Send {
+        AsLairStoreFactory::connect_to_store(&*self.0, unlock_secret)
+    }
+}

--- a/crates/lair_keystore_api/src/lib.rs
+++ b/crates/lair_keystore_api/src/lib.rs
@@ -16,11 +16,14 @@ pub type LairResult<T> = Result<T, one_err::OneErr>;
 pub mod config;
 pub mod encoding_types;
 pub mod internal;
+pub mod lair_store;
+pub mod mem_store;
 pub mod sodium_secretstream;
 
 /// re-export module of types generally used with lair
 pub mod prelude {
     pub use crate::config::*;
     pub use crate::encoding_types::*;
+    pub use crate::lair_store::*;
     pub use crate::LairResult;
 }

--- a/crates/lair_keystore_api/src/lib.rs
+++ b/crates/lair_keystore_api/src/lib.rs
@@ -13,12 +13,14 @@ include!(concat!(env!("OUT_DIR"), "/ver.rs"));
 /// Lair Result Type
 pub type LairResult<T> = Result<T, one_err::OneErr>;
 
+pub mod config;
 pub mod encoding_types;
 pub mod internal;
 pub mod sodium_secretstream;
 
 /// re-export module of types generally used with lair
 pub mod prelude {
+    pub use crate::config::*;
     pub use crate::encoding_types::*;
     pub use crate::LairResult;
 }

--- a/crates/lair_keystore_api/src/mem_store.rs
+++ b/crates/lair_keystore_api/src/mem_store.rs
@@ -1,0 +1,201 @@
+//! Lair in-memory store - usually for testing
+
+use crate::lair_store::traits::*;
+use crate::prelude::*;
+use futures::future::{BoxFuture, FutureExt};
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// create an in-memory LairStore
+pub fn create_mem_store_factory() -> LairStoreFactory {
+    LairStoreFactory(Arc::new(PrivMemStoreFactory))
+}
+
+// -- private -- //
+
+struct PrivMemStoreFactory;
+
+impl AsLairStoreFactory for PrivMemStoreFactory {
+    fn connect_to_store(
+        &self,
+        unlock_secret: sodoken::BufReadSized<32>,
+    ) -> BoxFuture<'static, LairResult<LairStore>> {
+        async move {
+            // construct a new in-memory store
+            // use the unlock_secret directly as our bidi context key
+            let inner = PrivMemStoreInner {
+                bidi_key: unlock_secret,
+                entry_by_tag: HashMap::new(),
+                ed_pk_to_tag: HashMap::new(),
+                x_pk_to_tag: HashMap::new(),
+            };
+
+            Ok(LairStore(Arc::new(PrivMemStore(Arc::new(RwLock::new(
+                inner,
+            ))))))
+        }
+        .boxed()
+    }
+}
+
+struct PrivMemStoreInner {
+    // key for encryption / decryption of secrets
+    bidi_key: sodoken::BufReadSized<32>,
+    // the actual entry store, keyed by tag
+    entry_by_tag: HashMap<Arc<str>, LairEntry>,
+    // index for signature pub key to tag
+    ed_pk_to_tag: HashMap<Ed25519PubKey, Arc<str>>,
+    // index for encryption pub key to tag
+    x_pk_to_tag: HashMap<X25519PubKey, Arc<str>>,
+}
+
+struct PrivMemStore(Arc<RwLock<PrivMemStoreInner>>);
+
+impl AsLairStore for PrivMemStore {
+    fn get_bidi_ctx_key(&self) -> sodoken::BufReadSized<32> {
+        self.0.read().bidi_key.clone()
+    }
+
+    fn list_entries(
+        &self,
+    ) -> BoxFuture<'static, LairResult<Vec<LairEntryInfo>>> {
+        // generate / list entry info for all entries in the store
+        let list = self
+            .0
+            .read()
+            .entry_by_tag
+            .values()
+            .map(|e| match &**e {
+                LairEntryInner::Seed { tag, seed_info, .. } => {
+                    LairEntryInfo::Seed {
+                        tag: tag.clone(),
+                        seed_info: seed_info.clone(),
+                    }
+                }
+                LairEntryInner::DeepLockedSeed { tag, seed_info, .. } => {
+                    LairEntryInfo::DeepLockedSeed {
+                        tag: tag.clone(),
+                        seed_info: seed_info.clone(),
+                    }
+                }
+                LairEntryInner::WkaTlsCert { tag, cert_info, .. } => {
+                    LairEntryInfo::WkaTlsCert {
+                        tag: tag.clone(),
+                        cert_info: cert_info.clone(),
+                    }
+                }
+            })
+            .collect();
+        async move { Ok(list) }.boxed()
+    }
+
+    fn write_entry(
+        &self,
+        entry: LairEntry,
+    ) -> BoxFuture<'static, LairResult<()>> {
+        // pull out the tag / indexes of the entry
+        let (tag, ed, x) = match &*entry {
+            LairEntryInner::Seed { tag, seed_info, .. } => (
+                tag.clone(),
+                Some(seed_info.ed25519_pub_key.clone()),
+                Some(seed_info.x25519_pub_key.clone()),
+            ),
+            LairEntryInner::DeepLockedSeed { tag, seed_info, .. } => (
+                tag.clone(),
+                Some(seed_info.ed25519_pub_key.clone()),
+                Some(seed_info.x25519_pub_key.clone()),
+            ),
+            LairEntryInner::WkaTlsCert { tag, .. } => (tag.clone(), None, None),
+        };
+
+        let mut lock = self.0.write();
+
+        // refuse to overwrite entries
+        if lock.entry_by_tag.contains_key(&tag) {
+            return async move { Err("tag already registered".into()) }.boxed();
+        }
+
+        // if we have a signature pub key, add that index
+        if let Some(ed) = ed {
+            lock.ed_pk_to_tag.insert(ed, tag.clone());
+        }
+
+        // if we have an encryption pub key, add that index
+        if let Some(x) = x {
+            lock.x_pk_to_tag.insert(x, tag.clone());
+        }
+
+        // insert the actual entry by tag
+        lock.entry_by_tag.insert(tag, entry);
+
+        drop(lock);
+        async move { Ok(()) }.boxed()
+    }
+
+    fn get_entry_by_tag(
+        &self,
+        tag: Arc<str>,
+    ) -> BoxFuture<'static, LairResult<LairEntry>> {
+        // look up / return an entry by tag
+        let res = self
+            .0
+            .read()
+            .entry_by_tag
+            .get(&tag)
+            .cloned()
+            .ok_or_else(|| "tag not found".into());
+        async move { res }.boxed()
+    }
+
+    fn get_entry_by_ed25519_pub_key(
+        &self,
+        ed25519_pub_key: Ed25519PubKey,
+    ) -> BoxFuture<'static, LairResult<LairEntry>> {
+        // look up / return an entry by signature pub key
+        let inner = self.0.clone();
+        async move {
+            let lock = inner.read();
+            let tag = lock
+                .ed_pk_to_tag
+                .get(&ed25519_pub_key)
+                .cloned()
+                .ok_or_else(|| one_err::OneErr::new("pub key not found"))?;
+            lock.entry_by_tag
+                .get(&tag)
+                .cloned()
+                .ok_or_else(|| "tag not found".into())
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_mem_store_sanity() {
+        // this is just a sanity / smoke test
+        // the store gets a more thorough workout in the in-proc server tests
+
+        let factory = create_mem_store_factory();
+
+        let store = factory
+            .connect_to_store(sodoken::BufReadSized::from([0xff; 32]))
+            .await
+            .unwrap();
+
+        let seed_info = store.new_seed("test-seed".into()).await.unwrap();
+        println!("generated new seed: {:#?}", seed_info);
+
+        let list = store.list_entries().await.unwrap();
+        println!("list_entries: {:#?}", list);
+        assert_eq!(1, list.len());
+
+        println!(
+            "entry: {:#?}",
+            store.get_entry_by_tag("test-seed".into()).await.unwrap()
+        );
+    }
+}


### PR DESCRIPTION
DEPENDS ON https://github.com/holochain/lair/pull/62

[Video Walkthrough (2:48)](https://www.youtube.com/watch?v=kEbM_5CMklM)

We want it to be pretty easy to write a new backend store for lair, so the api the store needs to impl is pretty straight forward. Additional logic to make the store easy to work with is written into the concrete wrapper for the store trait-object.