### PR TITLE
[new-lair-8] in-process keystore + ipc keystore

### DIFF
--- a/crates/lair_keystore_api/src/in_proc_keystore.rs
+++ b/crates/lair_keystore_api/src/in_proc_keystore.rs
@@ -1,0 +1,172 @@
+//! an in-process keystore that manages the entire lair server life-cycle
+//! without needing to call out to an external process.
+
+use crate::prelude::*;
+use std::future::Future;
+
+/// an in-process keystore that manages the entire lair server life-cycle
+/// without needing to call out to an external process.
+#[derive(Clone)]
+pub struct InProcKeystore {
+    config: LairServerConfig,
+    passphrase: sodoken::BufRead,
+    srv_hnd: crate::lair_server::LairServer,
+}
+
+impl InProcKeystore {
+    /// Construct a new InProcKeystore instance.
+    /// The internal server will already be "interactively" unlocked.
+    pub fn new<P>(
+        config: LairServerConfig,
+        store_factory: LairStoreFactory,
+        passphrase: P,
+    ) -> impl Future<Output = LairResult<Self>> + 'static + Send
+    where
+        P: Into<sodoken::BufRead> + 'static + Send,
+    {
+        async move {
+            let passphrase = passphrase.into();
+
+            // set up our server handler
+            let srv_hnd = crate::lair_server::spawn_lair_server_task(
+                config.clone(),
+                "lair-keystore-in-proc".into(),
+                crate::LAIR_VER.into(),
+                store_factory,
+            )
+            .await?;
+
+            // with an in-process store, there's no reason not to unlock
+            // it directly while creating the task
+            srv_hnd.unlock(passphrase.clone()).await?;
+
+            Ok(Self {
+                config,
+                passphrase,
+                srv_hnd,
+            })
+        }
+    }
+
+    /// Get the config used by the LairServer held by this InProcKeystore.
+    pub fn get_config(&self) -> LairServerConfig {
+        self.config.clone()
+    }
+
+    /// Get a new LairClient connection to this InProcKeystore server.
+    /// While not strictly necessary, this new connection will already
+    /// have verified the server identity via "Hello" as well as unlocked
+    /// the connection.
+    pub fn new_client(
+        &self,
+    ) -> impl Future<Output = LairResult<LairClient>> + 'static + Send {
+        let srv_pub_key = self.config.get_server_pub_key();
+        let passphrase = self.passphrase.clone();
+        let srv_hnd = self.srv_hnd.clone();
+        async move {
+            let srv_pub_key = srv_pub_key?;
+
+            // note, for now it greatly simplifies the implementation
+            // to just have the single server implementation expecting
+            // to process async read/write channels. This increases
+            // overhead for the in-process implementation, so, someday
+            // we could make a shortcut for this use-case.
+
+            // create a new duplex to simulate networking code
+            let (srv, cli) = tokio::io::duplex(4096);
+
+            // split into read/write halves
+            let (srv_recv, srv_send) = tokio::io::split(srv);
+            let (cli_recv, cli_send) = tokio::io::split(cli);
+
+            // get the server accept future
+            let srv_fut = srv_hnd.accept(srv_send, srv_recv);
+
+            // get the client wrap future
+            let cli_fut =
+                crate::lair_client::async_io::new_async_io_lair_client(
+                    cli_send, cli_recv,
+                );
+
+            // await both futures at the same time so they can
+            // exchange information
+            let (_, cli_hnd) =
+                futures::future::try_join(srv_fut, cli_fut).await?;
+
+            // verify server identity
+            cli_hnd.hello(srv_pub_key).await?;
+
+            // unlock the connection
+            cli_hnd.unlock(passphrase).await?;
+
+            Ok(cli_hnd)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn in_proc_happy_path() {
+        // set up a passphrase
+        let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
+
+        // create the config for the test server
+        // the path is immaterial since we'll be using an in-memory store
+        let config = Arc::new(
+            hc_seed_bundle::PwHashLimits::Interactive
+                .with_exec(|| {
+                    LairServerConfigInner::new("/", passphrase.clone())
+                })
+                .await
+                .unwrap(),
+        );
+
+        // create an in-process keystore with an in-memory store
+        let keystore = InProcKeystore::new(
+            config,
+            crate::mem_store::create_mem_store_factory(),
+            passphrase.clone(),
+        )
+        .await
+        .unwrap();
+
+        let config = keystore.get_config();
+        println!("{}", config);
+
+        // create a client connection to the keystore
+        let client = keystore.new_client().await.unwrap();
+
+        // create a new seed
+        let seed_info_ref =
+            client.new_seed("test-tag".into(), None).await.unwrap();
+
+        // list keystore contents
+        let mut entry_list = client.list_entries().await.unwrap();
+
+        assert_eq!(1, entry_list.len());
+        match entry_list.remove(0) {
+            LairEntryInfo::Seed { tag, seed_info } => {
+                assert_eq!("test-tag", &*tag);
+                assert_eq!(seed_info, seed_info_ref);
+            }
+            oth => panic!("unexpected: {:?}", oth),
+        }
+
+        // create a new deep-locked seed
+        let _seed_info_ref_deep = hc_seed_bundle::PwHashLimits::Interactive
+            .with_exec(|| {
+                client.new_seed(
+                    "test-tag-deep".into(),
+                    Some(sodoken::BufRead::from(&b"deep"[..])),
+                )
+            })
+            .await
+            .unwrap();
+
+        println!("{:#?}", client.list_entries().await.unwrap());
+    }
+}

--- a/crates/lair_keystore_api/src/ipc_keystore.rs
+++ b/crates/lair_keystore_api/src/ipc_keystore.rs
@@ -1,0 +1,302 @@
+//! client / server keystore items for dealing with ipc keystores,
+//! both unix domain sockets and windows named pipes.
+
+use crate::prelude::*;
+use futures::stream::StreamExt;
+use std::future::Future;
+
+mod raw_ipc;
+
+/// server keystore item for dealing with ipc keystores,
+/// both unix domain sockets and windows named pipes.
+#[derive(Clone)]
+pub struct IpcKeystoreServer {
+    config: LairServerConfig,
+    srv_hnd: crate::lair_server::LairServer,
+}
+
+impl IpcKeystoreServer {
+    /// Construct a new IpcKeystoreServer instance.
+    /// The internal server will initially be LOCKED.
+    /// You must call 'unlock' if you wish to "interactively" unlock.
+    pub fn new(
+        config: LairServerConfig,
+        store_factory: LairStoreFactory,
+    ) -> impl Future<Output = LairResult<Self>> + 'static + Send {
+        async move {
+            let con_recv = raw_ipc::ipc_bind(config.clone()).await?;
+
+            // set up our server handler
+            let srv_hnd = crate::lair_server::spawn_lair_server_task(
+                config.clone(),
+                "lair-keystore-ipc".into(),
+                crate::LAIR_VER.into(),
+                store_factory,
+            )
+            .await?;
+
+            {
+                // set up a tokio task for accepting incoming connections
+                let srv_hnd = srv_hnd.clone();
+                tokio::task::spawn(async move {
+                    let srv_hnd = &srv_hnd;
+                    con_recv.for_each_concurrent(4096, |incoming| async move {
+                        let (send, recv) = match incoming {
+                            Err(e) => {
+                                tracing::error!("Error accepting incoming ipc connection: {:?}", e);
+                                return;
+                            }
+                            Ok(r) => r,
+                        };
+                        if let Err(e) = srv_hnd.accept(send, recv).await {
+                            tracing::error!("Error accepting incoming ipc connection: {:?}", e);
+                        }
+                    }).await;
+
+                    tracing::error!(
+                        "IpcKeystoreServer ipc_raw con recv loop ended!"
+                    );
+                });
+            }
+
+            Ok(Self { config, srv_hnd })
+        }
+    }
+
+    /// "interactively" unlock this keystore from the server side.
+    /// This is the preferred way to unlock a keystore... if unlocked
+    /// through the client api, the client has no way to know if this
+    /// server is authentic before potentially passing the passphrase
+    /// to a third party attacker (MitM).
+    pub fn unlock<P>(
+        &self,
+        passphrase: P,
+    ) -> impl Future<Output = LairResult<()>> + 'static + Send
+    where
+        P: Into<sodoken::BufRead> + 'static + Send,
+    {
+        self.srv_hnd.unlock(passphrase.into())
+    }
+
+    /// Get the config used by the LairServer held by this IpcKeystoreServer.
+    pub fn get_config(&self) -> LairServerConfig {
+        self.config.clone()
+    }
+}
+
+/// Client connection options for customizing how to connect to an ipc server.
+pub struct IpcKeystoreClientOptions {
+    /// the ipc url ('unix://' or 'named-pipe:\\.\pipe\[yada]') to connect to
+    pub connection_url: url::Url,
+    /// the passphrase to use to connect
+    pub passphrase: sodoken::BufRead,
+    /// Require the client and server to have exactly matching
+    /// client / server versions.
+    pub exact_client_server_version_match: bool,
+    /// If it is not possible to unlock the server "interactively" on
+    /// the server side... we can unlock it from the client side without
+    /// validating the server's authenticity...
+    /// If the server is NOT authentic, we will get an error, but we
+    /// also will have supplied our passphrase to an attacker.
+    pub danger_unlock_without_server_validate: bool,
+}
+
+/// Connect to an IpcKeystoreServer instance via
+/// unix domain socket on linux/macOs or named pipe on windows.
+/// This constructor will first validate server authenticity,
+/// then unlock the connection with the supplied passphrase.
+pub fn ipc_keystore_connect<P>(
+    connection_url: url::Url,
+    passphrase: P,
+) -> impl Future<Output = LairResult<LairClient>> + 'static + Send
+where
+    P: Into<sodoken::BufRead> + 'static + Send,
+{
+    let passphrase = passphrase.into();
+    ipc_keystore_connect_options(IpcKeystoreClientOptions {
+        connection_url,
+        passphrase,
+        exact_client_server_version_match: false,
+        danger_unlock_without_server_validate: false,
+    })
+}
+
+/// Connect to an IpcKeystoreServer instance via
+/// unix domain socket on linux/macOs or named pipe on windows.
+pub fn ipc_keystore_connect_options(
+    opts: IpcKeystoreClientOptions,
+) -> impl Future<Output = LairResult<LairClient>> + 'static + Send {
+    async move {
+        let server_pub_key =
+            get_server_pub_key_from_connection_url(&opts.connection_url)?;
+
+        // establish the raw ipc connection
+        let (send, recv) =
+            raw_ipc::ipc_connect(opts.connection_url.clone()).await?;
+
+        // wrap this connection up as a LairClient
+        let cli_hnd =
+            crate::lair_client::async_io::new_async_io_lair_client(send, recv)
+                .await?;
+
+        if opts.danger_unlock_without_server_validate {
+            // even if they tell us to do this backwards,
+            // let's at least try to do it correctly to start
+            match cli_hnd.hello(server_pub_key.clone()).await {
+                Ok(ver) => {
+                    priv_check_hello_ver(&opts, &ver)?;
+
+                    // hey, it worked, unlock and proceed
+                    cli_hnd.unlock(opts.passphrase.clone()).await?;
+                }
+                Err(e) if e.str_kind() == "KestoreLocked" => {
+                    // lame, the server really is not unlocked...
+                    // unlock, but some attacker may get our passphrase
+                    cli_hnd.unlock(opts.passphrase.clone()).await?;
+
+                    // now do the verification, and hope it was
+                    // the correct server
+                    let ver = cli_hnd.hello(server_pub_key).await?;
+                    priv_check_hello_ver(&opts, &ver)?;
+                }
+                Err(e) => return Err(e),
+            }
+        } else {
+            // the normal way is much more straight forward
+            let ver = cli_hnd.hello(server_pub_key).await?;
+            priv_check_hello_ver(&opts, &ver)?;
+            cli_hnd.unlock(opts.passphrase).await?;
+        }
+
+        Ok(cli_hnd)
+    }
+}
+
+fn priv_check_hello_ver(
+    opts: &IpcKeystoreClientOptions,
+    server_version: &str,
+) -> LairResult<()> {
+    if opts.exact_client_server_version_match
+        && server_version != crate::LAIR_VER
+    {
+        return Err(format!(
+            "Invalid lair server version, this client requires '{}', but got '{}'.",
+            crate::LAIR_VER,
+            server_version,
+        ).into());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ipc_happy_path() {
+        let tmp_dir = tempdir::TempDir::new("lair_ipc_keystore_test").unwrap();
+
+        // set up a passphrase
+        let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
+
+        // create the config for the test server
+        // the path is immaterial since we'll be using an in-memory store
+        let config = Arc::new(
+            hc_seed_bundle::PwHashLimits::Interactive
+                .with_exec(|| {
+                    LairServerConfigInner::new(
+                        tmp_dir.path(),
+                        passphrase.clone(),
+                    )
+                })
+                .await
+                .unwrap(),
+        );
+
+        // create an in-process keystore with an in-memory store
+        let keystore = IpcKeystoreServer::new(
+            config,
+            crate::mem_store::create_mem_store_factory(),
+        )
+        .await
+        .unwrap();
+
+        let config = keystore.get_config();
+        println!("{}", config);
+
+        // unlock the keystore "interactively" from the server side
+        keystore.unlock(passphrase.clone()).await.unwrap();
+
+        // create a client connection
+        let client =
+            ipc_keystore_connect(config.connection_url.clone(), passphrase)
+                .await
+                .unwrap();
+
+        // create a new seed
+        let seed_info_ref =
+            client.new_seed("test-tag".into(), None).await.unwrap();
+
+        // list keystore contents
+        let mut entry_list = client.list_entries().await.unwrap();
+
+        assert_eq!(1, entry_list.len());
+        match entry_list.remove(0) {
+            LairEntryInfo::Seed { tag, seed_info } => {
+                assert_eq!("test-tag", &*tag);
+                assert_eq!(seed_info, seed_info_ref);
+            }
+            oth => panic!("unexpected: {:?}", oth),
+        }
+
+        let entry = client.get_entry("test-tag".into()).await.unwrap();
+
+        match entry {
+            LairEntryInfo::Seed { tag, seed_info } => {
+                assert_eq!("test-tag", &*tag);
+                assert_eq!(seed_info, seed_info_ref);
+            }
+            oth => panic!("unexpected: {:?}", oth),
+        }
+
+        let sig = client
+            .sign_by_pub_key(
+                seed_info_ref.ed25519_pub_key.clone(),
+                None,
+                b"hello".to_vec().into(),
+            )
+            .await
+            .unwrap();
+        assert!(seed_info_ref
+            .ed25519_pub_key
+            .verify_detached(sig, &b"hello"[..])
+            .await
+            .unwrap());
+
+        // create a new deep-locked seed
+        let _seed_info_ref_deep = hc_seed_bundle::PwHashLimits::Interactive
+            .with_exec(|| {
+                client.new_seed(
+                    "test-tag-deep".into(),
+                    Some(sodoken::BufRead::from(&b"deep"[..])),
+                )
+            })
+            .await
+            .unwrap();
+
+        // create a new tls certificate
+        let cert_info =
+            client.new_wka_tls_cert("test-cert".into()).await.unwrap();
+        println!("{:#?}", cert_info);
+
+        let priv_key = client
+            .get_wka_tls_cert_priv_key("test-cert".into())
+            .await
+            .unwrap();
+        println!("got priv key: {} bytes", priv_key.len());
+
+        println!("{:#?}", client.list_entries().await.unwrap());
+    }
+}

--- a/crates/lair_keystore_api/src/ipc_keystore.rs
+++ b/crates/lair_keystore_api/src/ipc_keystore.rs
@@ -149,7 +149,7 @@ pub fn ipc_keystore_connect_options(
                     // hey, it worked, unlock and proceed
                     cli_hnd.unlock(opts.passphrase.clone()).await?;
                 }
-                Err(e) if e.str_kind() == "KestoreLocked" => {
+                Err(e) if e.str_kind() == "KeystoreLocked" => {
                     // lame, the server really is not unlocked...
                     // unlock, but some attacker may get our passphrase
                     cli_hnd.unlock(opts.passphrase.clone()).await?;

--- a/crates/lair_keystore_api/src/ipc_keystore/raw_ipc.rs
+++ b/crates/lair_keystore_api/src/ipc_keystore/raw_ipc.rs
@@ -1,0 +1,162 @@
+#![allow(dead_code)]
+use super::*;
+
+pub(crate) type IpcSend =
+    Box<dyn tokio::io::AsyncWrite + 'static + Send + Unpin>;
+pub(crate) type IpcRecv =
+    Box<dyn tokio::io::AsyncRead + 'static + Send + Unpin>;
+pub(crate) type IpcConRecv =
+    futures::stream::BoxStream<'static, LairResult<(IpcSend, IpcRecv)>>;
+
+// -- unix/macOs implementation -- //
+
+#[cfg(not(windows))]
+pub(crate) fn ipc_connect(
+    connection_url: url::Url,
+) -> impl Future<Output = LairResult<(IpcSend, IpcRecv)>> + 'static + Send {
+    async move {
+        if connection_url.scheme() != "unix" {
+            return Err(
+                "IpcKeystore connection on unix/macOs must be 'unix:' scheme."
+                    .into(),
+            );
+        }
+
+        // connect the socket
+        let path = connection_url.path();
+        let socket = tokio::net::UnixStream::connect(path)
+            .await
+            .map_err(one_err::OneErr::new)?;
+
+        // split into send / recv halves
+        let (recv, send) = socket.into_split();
+
+        // box and return
+        let send: IpcSend = Box::new(send);
+        let recv: IpcRecv = Box::new(recv);
+        Ok((send, recv))
+    }
+}
+
+#[cfg(not(windows))]
+pub(crate) fn ipc_bind(
+    config: LairServerConfig,
+) -> impl Future<Output = LairResult<IpcConRecv>> + 'static + Send {
+    async move {
+        if config.get_connection_scheme() != "unix" {
+            return Err(
+                "IpcKeystore connection on unix/macOs must be 'unix:' scheme."
+                    .into(),
+            );
+        }
+
+        let path = config.get_connection_path();
+
+        // we've already acquired our pid_file
+        // it's safe to say we own the domain socket
+        // and can remove any previous remnant
+        let _ = tokio::fs::remove_file(path).await;
+
+        // bind to the domain socket
+        let socket = tokio::net::UnixListener::bind(path)?;
+
+        // consecutively read incoming connections / forward them
+        let recv: IpcConRecv =
+            futures::stream::try_unfold(socket, |socket| async move {
+                let (con, _) = socket.accept().await?;
+                let (recv, send) = con.into_split();
+                let send: IpcSend = Box::new(send);
+                let recv: IpcRecv = Box::new(recv);
+                Ok(Some(((send, recv), socket)))
+            })
+            .boxed();
+
+        Ok(recv)
+    }
+}
+
+// -- windows implementation -- //
+
+#[cfg(windows)]
+pub(crate) fn ipc_connect(
+    connection_url: url::Url,
+) -> impl Future<Output = LairResult<(IpcSend, IpcRecv)>> + 'static + Send {
+    async move {
+        if connection_url.scheme() != "named-pipe" {
+            return Err("IpcKeystore connection on windows must be 'named-pipe:' scheme.".into());
+        }
+
+        // this loop is verbatim from the tokio docs
+        let path = connection_url.path();
+        let pipe = loop {
+            match tokio::net::windows::named_pipe::ClientOptions::new()
+                .open(path)
+            {
+                Ok(client) => break client,
+                Err(e)
+                    if e.raw_os_error()
+                        == Some(
+                            winapi::shared::winerror::ERROR_PIPE_BUSY as i32,
+                        ) =>
+                {
+                    ()
+                }
+                Err(e) => return Err(one_err::OneErr::new(e)),
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        };
+
+        // split into send / recv halves
+        let (recv, send) = tokio::io::split(pipe);
+
+        // box and return
+        let send: IpcSend = Box::new(send);
+        let recv: IpcRecv = Box::new(recv);
+        Ok((send, recv))
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn ipc_bind(
+    config: LairServerConfig,
+) -> impl Future<Output = LairResult<IpcConRecv>> + 'static + Send {
+    async move {
+        if config.get_connection_scheme() != "named-pipe" {
+            return Err("IpcKeystore connection on windows must be 'named-pipe:' scheme.".into());
+        }
+
+        let path = config.get_connection_path().to_owned();
+
+        // open the initial named pipe server-side acceptor
+        // note the special first_pipe_instance flag.
+        // windows named pipes are weird...
+        let pipe = tokio::net::windows::named_pipe::ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(&path)?;
+
+        // loop on accepting incoming connections
+        let recv: IpcConRecv = futures::stream::try_unfold(
+            (path, pipe),
+            |(path, pipe)| async move {
+                // await a client connection
+                pipe.connect().await?;
+
+                // windows named pipes are weird...
+                // you just make a successive stream of servers
+                // with the same name...
+                let next_pipe =
+                    tokio::net::windows::named_pipe::ServerOptions::new()
+                        .create(&path)?;
+
+                // return the connection we established
+                let (recv, send) = tokio::io::split(pipe);
+                let send: IpcSend = Box::new(send);
+                let recv: IpcRecv = Box::new(recv);
+                Ok(Some(((send, recv), (path, next_pipe))))
+            },
+        )
+        .boxed();
+
+        Ok(recv)
+    }
+}

--- a/crates/lair_keystore_api/src/lib.rs
+++ b/crates/lair_keystore_api/src/lib.rs
@@ -15,7 +15,9 @@ pub type LairResult<T> = Result<T, one_err::OneErr>;
 
 pub mod config;
 pub mod encoding_types;
+pub mod in_proc_keystore;
 pub mod internal;
+pub mod ipc_keystore;
 pub mod lair_api;
 pub mod lair_client;
 pub mod lair_server;


### PR DESCRIPTION
DEPENDS ON https://github.com/holochain/lair/pull/66

[Video Walkthrough (3:30)](https://www.youtube.com/watch?v=i3-bWkZj8sU)

Two server wrappers:
- one that uses `tokio::io::duplex` to facilitate an in-process keystore server, i.e. could be used for testing
- one that uses unix domain sockets on most systems or windows named-pipes on windows