### PR TITLE
[new-lair-11] import seed_bundle lair-keystore cli command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
 name = "lair_keystore"
 version = "0.1.0-alpha.1"
 dependencies = [
+ "base64",
  "criterion",
  "dunce",
  "futures",

--- a/crates/hc_seed_bundle/src/unlocked_seed_bundle.rs
+++ b/crates/hc_seed_bundle/src/unlocked_seed_bundle.rs
@@ -51,6 +51,11 @@ impl UnlockedSeedBundle {
         crate::LockedSeedCipher::from_locked(bytes)
     }
 
+    /// Get the actual seed tracked by this seed bundle.
+    pub fn get_seed(&self) -> sodoken::BufReadSized<32> {
+        self.seed.clone()
+    }
+
     /// Derive a new sub SeedBundle by given index.
     pub fn derive(
         &self,

--- a/crates/lair_keystore/Cargo.toml
+++ b/crates/lair_keystore/Cargo.toml
@@ -12,6 +12,7 @@ categories = [ "cryptography" ]
 edition = "2018"
 
 [dependencies]
+base64 = "0.13.0"
 dunce = "1.0.2"
 futures = "0.3.17"
 hc_seed_bundle = { version = "=0.1.0-alpha.1", path = "../hc_seed_bundle" }

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_import_seed.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_import_seed.rs
@@ -1,0 +1,188 @@
+use super::*;
+
+pub(crate) async fn exec(
+    config: LairServerConfig,
+    opt: OptImportSeed,
+) -> LairResult<()> {
+    // we need to capture the pid_file to run a seed bundle import
+    // i.e. we cannot do this while a server is running.
+    {
+        let config = config.clone();
+        // TODO - make pid_check async friendly
+        tokio::task::spawn_blocking(move || {
+            lair_keystore_lib::pid_check::pid_check(&config)
+        })
+        .await
+        .map_err(one_err::OneErr::new)??;
+    }
+
+    let (store_pass, bundle_pass, deep_pass) = if opt.piped {
+        let multi = read_piped_passphrase().await?;
+        let multi = multi.read_lock();
+
+        // careful not to move any bytes out of protected memory
+        // convert to utf8 so we can use the rust split.
+        let multi =
+            std::str::from_utf8(&*multi).map_err(one_err::OneErr::new)?;
+        let mut pass_list = multi
+            .split('\n')
+            .filter_map(|s| {
+                let s = s.trim();
+                let s = s.as_bytes();
+                if s.is_empty() {
+                    None
+                } else {
+                    let n = sodoken::BufWrite::new_mem_locked(s.len())
+                        .expect("failed to allocate locked BufWrite");
+                    {
+                        let mut n = n.write_lock();
+                        n.copy_from_slice(s);
+                    }
+                    Some(n.to_read())
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if opt.deep_lock {
+            if pass_list.len() != 3 {
+                return Err("expected 3 newline delimited passphrases".into());
+            }
+            (
+                pass_list.remove(0),
+                pass_list.remove(0),
+                Some(pass_list.remove(0)),
+            )
+        } else {
+            if pass_list.len() != 2 {
+                return Err("expected 2 newline delimited passphrases".into());
+            }
+            (pass_list.remove(0), pass_list.remove(0), None)
+        }
+    } else {
+        (
+            read_interactive_passphrase("\n# store passphrase> ").await?,
+            read_interactive_passphrase("\n# bundle passphrase> ").await?,
+            if opt.deep_lock {
+                Some(
+                    read_interactive_passphrase("\n# deep-lock passphrase> ")
+                        .await?,
+                )
+            } else {
+                None
+            },
+        )
+    };
+
+    let bundle_bytes =
+        base64::decode_config(&opt.seed_bundle_base64, base64::URL_SAFE_NO_PAD)
+            .map_err(one_err::OneErr::new)?;
+    let cipher_list =
+        hc_seed_bundle::UnlockedSeedBundle::from_locked(&bundle_bytes).await?;
+
+    let mut bundle = None;
+    for cipher in cipher_list {
+        use hc_seed_bundle::LockedSeedCipher::*;
+        match cipher {
+            PwHash(pw_hash) => {
+                match pw_hash.unlock(bundle_pass.clone()).await {
+                    Ok(b) => {
+                        bundle = Some(b);
+                        break;
+                    }
+                    _ => continue,
+                }
+            }
+            _ => continue,
+        }
+    }
+
+    let bundle = bundle
+        .ok_or_else(|| one_err::OneErr::from("could not unlock seed bundle"))?;
+
+    let seed = bundle.get_seed();
+
+    // derive the ed25519 signature keypair from this seed
+    let ed_pk = sodoken::BufWriteSized::new_no_lock();
+    let ed_sk = sodoken::BufWriteSized::new_mem_locked()?;
+    sodoken::sign::seed_keypair(ed_pk.clone(), ed_sk, seed.clone()).await?;
+
+    // derive the x25519 encryption keypair from this seed
+    let x_pk = sodoken::BufWriteSized::new_no_lock();
+    let x_sk = sodoken::BufWriteSized::new_mem_locked()?;
+    sodoken::sealed_box::curve25519xchacha20poly1305::seed_keypair(
+        x_pk.clone(),
+        x_sk,
+        seed.clone(),
+    )
+    .await?;
+
+    // populate our seed info with the derived public keys
+    let seed_info = SeedInfo {
+        ed25519_pub_key: ed_pk.try_unwrap_sized().unwrap().into(),
+        x25519_pub_key: x_pk.try_unwrap_sized().unwrap().into(),
+    };
+
+    let store_factory =
+        lair_keystore_lib::store_sqlite::create_sql_pool_factory(
+            &config.store_file,
+        );
+
+    let srv_hnd = lair_keystore_api::ipc_keystore::IpcKeystoreServer::new(
+        config,
+        store_factory,
+    )
+    .await?;
+
+    srv_hnd.unlock(store_pass).await?;
+
+    let store = srv_hnd.store().await?;
+
+    let entry = if let Some(deep_pass) = deep_pass {
+        // generate the salt for the pwhash deep locking
+        let salt = <sodoken::BufWriteSized<16>>::new_no_lock();
+        sodoken::random::bytes_buf(salt.clone()).await?;
+
+        let limits = hc_seed_bundle::PwHashLimits::Moderate;
+        let ops_limit = limits.as_ops_limit();
+        let mem_limit = limits.as_mem_limit();
+
+        // generate the deep lock key from the passphrase
+        let key = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+        sodoken::hash::argon2id::hash(
+            key.clone(),
+            deep_pass,
+            salt.clone(),
+            ops_limit,
+            mem_limit,
+        )
+        .await?;
+
+        // encrypt the seed with the deep lock key
+        let seed = SecretDataSized::encrypt(key.to_read_sized(), seed).await?;
+
+        // construct the entry for the keystore
+        LairEntryInner::DeepLockedSeed {
+            tag: opt.tag.as_str().into(),
+            seed_info: seed_info.clone(),
+            salt: salt.try_unwrap_sized().unwrap().into(),
+            ops_limit,
+            mem_limit,
+            seed,
+        }
+    } else {
+        let key = store.get_bidi_ctx_key();
+        let seed = SecretDataSized::encrypt(key, seed).await?;
+
+        LairEntryInner::Seed {
+            tag: opt.tag.as_str().into(),
+            seed_info: seed_info.clone(),
+            seed,
+        }
+    };
+
+    store.0.write_entry(Arc::new(entry)).await?;
+
+    println!("# imported seed {} {:?}", opt.tag, seed_info);
+
+    Ok(())
+}

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_init.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_init.rs
@@ -24,7 +24,7 @@ pub(crate) async fn exec(
     let passphrase = if opt.piped {
         read_piped_passphrase().await?
     } else {
-        read_interactive_passphrase().await?
+        read_interactive_passphrase("\n# passphrase> ").await?
     };
 
     println!("\n# lair-keystore init generating secure config...");

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_server.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_server.rs
@@ -11,7 +11,7 @@ pub(crate) async fn exec(
     }
 
     // construct the server so that pid-check etc happens first
-    let server =
+    let mut server =
         lair_keystore_lib::server::StandaloneServer::new(config).await?;
 
     let passphrase = if opt.piped {

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_server.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_server.rs
@@ -19,7 +19,7 @@ pub(crate) async fn exec(
     } else if opt.locked {
         None
     } else {
-        Some(read_interactive_passphrase().await?)
+        Some(read_interactive_passphrase("\n# passphrase> ").await?)
     };
 
     if let Some(passphrase) = passphrase {

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/main.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/main.rs
@@ -14,6 +14,7 @@ use structopt::StructOpt;
 
 pub(crate) const CONFIG_N: &str = "lair-keystore-config.yaml";
 
+mod cmd_import_seed;
 mod cmd_init;
 mod cmd_server;
 mod cmd_url;
@@ -35,11 +36,13 @@ fn vec_to_locked(mut pass_tmp: Vec<u8>) -> LairResult<sodoken::BufRead> {
     }
 }
 
-pub(crate) async fn read_interactive_passphrase() -> LairResult<sodoken::BufRead>
-{
-    let pass_tmp = tokio::task::spawn_blocking(|| {
+pub(crate) async fn read_interactive_passphrase(
+    prompt: &str,
+) -> LairResult<sodoken::BufRead> {
+    let prompt = prompt.to_owned();
+    let pass_tmp = tokio::task::spawn_blocking(move || {
         LairResult::Ok(
-            rpassword::read_password_from_tty(Some("\n# passphrase> "))
+            rpassword::read_password_from_tty(Some(&prompt))
                 .map_err(one_err::OneErr::new)?
                 .into_bytes(),
         )
@@ -98,9 +101,37 @@ pub(crate) struct OptServer {
 }
 
 #[derive(Debug, StructOpt)]
+pub(crate) struct OptImportSeed {
+    /// Instead of the normal "interactive" method of passphrase
+    /// retreival, read the passphrase from stdin. Be careful
+    /// how you make use of this, as it could be less secure.
+    /// Passphrases are newline delimited in this order:
+    /// - 1 - keystore unlock passphrase
+    /// - 2 - bundle unlock passphrase
+    /// - 3 - deep lock passphrase
+    ///       (if -d / --deep-lock is specified)
+    #[structopt(short = "p", long, verbatim_doc_comment)]
+    pub piped: bool,
+
+    /// Specify that this seed should be loaded as a
+    /// "deep-locked" seed. This seed will require an
+    /// additional passphrase specified at access time
+    /// (signature / box / key derivation) to decrypt the seed.
+    #[structopt(short = "d", long, verbatim_doc_comment)]
+    pub deep_lock: bool,
+
+    /// The identification tag for this seed.
+    #[structopt(verbatim_doc_comment)]
+    pub tag: String,
+
+    /// The base64url encoded hc_seed_bundle.
+    #[structopt(verbatim_doc_comment)]
+    pub seed_bundle_base64: String,
+}
+
+#[derive(Debug, StructOpt)]
 enum Cmd {
-    /// Set up a new lair private keystore. Currently '-i'
-    /// is required to specify the passphrase interactively.
+    /// Set up a new lair private keystore.
     #[structopt(verbatim_doc_comment)]
     Init(OptInit),
 
@@ -114,6 +145,15 @@ enum Cmd {
     /// 'lair-keystore init'.
     #[structopt(verbatim_doc_comment)]
     Server(OptServer),
+
+    /// Load a seed bundle into this lair-keystore instance.
+    /// Note, this operation requires capturing the pid_file,
+    /// make sure you do not have a lair-server running.
+    /// Note, we currently only support importing seed bundles
+    /// with a pwhash cipher. We'll try the passphrase you
+    /// supply with all ciphers used to lock the bundle.
+    #[structopt(verbatim_doc_comment)]
+    ImportSeed(OptImportSeed),
 }
 
 #[derive(Debug, StructOpt)]
@@ -163,6 +203,10 @@ async fn exec() -> LairResult<()> {
         Cmd::Server(opt) => {
             let config = get_config(lair_root.as_path()).await?;
             cmd_server::exec(config, opt).await
+        }
+        Cmd::ImportSeed(opt) => {
+            let config = get_config(lair_root.as_path()).await?;
+            cmd_import_seed::exec(config, opt).await
         }
     }
 }

--- a/crates/lair_keystore_api/src/ipc_keystore.rs
+++ b/crates/lair_keystore_api/src/ipc_keystore.rs
@@ -78,6 +78,14 @@ impl IpcKeystoreServer {
         self.srv_hnd.unlock(passphrase.into())
     }
 
+    /// get a handle to the LairStore instantiated by this server,
+    /// may error if a store has not yet been created.
+    pub fn store(
+        &self,
+    ) -> impl Future<Output = LairResult<LairStore>> + 'static + Send {
+        self.srv_hnd.store()
+    }
+
     /// Get the config used by the LairServer held by this IpcKeystoreServer.
     pub fn get_config(&self) -> LairServerConfig {
         self.config.clone()

--- a/crates/lair_keystore_api/src/lair_server.rs
+++ b/crates/lair_keystore_api/src/lair_server.rs
@@ -35,6 +35,10 @@ pub mod traits {
             send: RawSend,
             recv: RawRecv,
         ) -> BoxFuture<'static, LairResult<()>>;
+
+        /// get a handle to the LairStore instantiated by this server,
+        /// may error if a store has not yet been created.
+        fn store(&self) -> BoxFuture<'static, LairResult<LairStore>>;
     }
 }
 use traits::*;
@@ -64,6 +68,14 @@ impl LairServer {
         R: tokio::io::AsyncRead + 'static + Send + Unpin,
     {
         AsLairServer::accept(&*self.0, Box::new(send), Box::new(recv))
+    }
+
+    /// get a handle to the LairStore instantiated by this server,
+    /// may error if a store has not yet been created.
+    pub fn store(
+        &self,
+    ) -> impl Future<Output = LairResult<LairStore>> + 'static + Send {
+        AsLairServer::store(&*self.0)
     }
 }
 

--- a/crates/lair_keystore_api/src/lair_server/priv_srv.rs
+++ b/crates/lair_keystore_api/src/lair_server/priv_srv.rs
@@ -347,4 +347,15 @@ impl AsLairServer for Srv {
     ) -> BoxFuture<'static, LairResult<()>> {
         priv_srv_accept(self.0.clone(), send, recv)
     }
+
+    fn store(&self) -> BoxFuture<'static, LairResult<LairStore>> {
+        let store = match &*self.0.read() {
+            SrvInnerEnum::Running(p) => p.store.clone(),
+            SrvInnerEnum::Pending(_) => {
+                return async move { Err("server locked, no store".into()) }
+                    .boxed();
+            }
+        };
+        async move { Ok(store) }.boxed()
+    }
 }


### PR DESCRIPTION
DEPENDS ON https://github.com/holochain/lair/pull/69

[Video Walkthrough (2:15)](https://www.youtube.com/watch?v=cS4KzoTg5UY)

Allow importing hc_seed_bundle bundles from quickstart / etc into a lair keystore store using the lair-keystore binary cli.