### PR TITLE
fix lair server identity verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,9 +1259,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "sodoken"
-version = "0.0.1-alpha.18"
+version = "0.0.1-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba31515b2b4b4f05179ccb1bca9bec791e115b33fe8b08af2c576941b312c0f5"
+checksum = "40a1e3ce2d027f17fe3f4b688b293e519d884ae9ef6c698bdc4d6dacf4ebb245"
 dependencies = [
  "libc",
  "libsodium-sys",

--- a/crates/hc_seed_bundle/Cargo.toml
+++ b/crates/hc_seed_bundle/Cargo.toml
@@ -17,7 +17,7 @@ rmp-serde = "0.15.5"
 rmpv = { version = "1.0.0", features = [ "with-serde" ] }
 serde = { version = "1", features = [ "derive", "rc" ] }
 serde_bytes = "0.11.5"
-sodoken = "=0.0.1-alpha.18"
+sodoken = "=0.0.1-alpha.20"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/crates/lair_keystore/Cargo.toml
+++ b/crates/lair_keystore/Cargo.toml
@@ -20,7 +20,7 @@ lair_keystore_api = { version = "=0.1.0-alpha.1", path = "../lair_keystore_api" 
 one_err = "0.0.4"
 parking_lot = "0.11.2"
 rpassword = "5.0.1"
-sodoken = "=0.0.1-alpha.18"
+sodoken = "=0.0.1-alpha.20"
 structopt = "0.3.23"
 sysinfo = "0.20.3"
 tokio = { version = "1.12.0", features = [ "full" ] }

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_import_seed.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_import_seed.rs
@@ -67,7 +67,7 @@ pub(crate) async fn exec(
     };
 
     // unlock the server
-    server.run_unlocked(store_pass).await?;
+    server.run(store_pass).await?;
 
     // load the bundle
     let bundle_bytes =
@@ -108,7 +108,7 @@ pub(crate) async fn exec(
     // derive the x25519 encryption keypair from this seed
     let x_pk = sodoken::BufWriteSized::new_no_lock();
     let x_sk = sodoken::BufWriteSized::new_mem_locked()?;
-    sodoken::sealed_box::curve25519xchacha20poly1305::seed_keypair(
+    sodoken::crypto_box::curve25519xchacha20poly1305::seed_keypair(
         x_pk.clone(),
         x_sk,
         seed.clone(),

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_server.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/cmd_server.rs
@@ -4,29 +4,17 @@ pub(crate) async fn exec(
     config: LairServerConfig,
     opt: OptServer,
 ) -> LairResult<()> {
-    if opt.piped && opt.locked {
-        return Err(
-            "-p / --piped and -l / --locked are mutually exclusive".into()
-        );
-    }
-
     // construct the server so that pid-check etc happens first
     let mut server =
         lair_keystore_lib::server::StandaloneServer::new(config).await?;
 
     let passphrase = if opt.piped {
-        Some(read_piped_passphrase().await?)
-    } else if opt.locked {
-        None
+        read_piped_passphrase().await?
     } else {
-        Some(read_interactive_passphrase("\n# passphrase> ").await?)
+        read_interactive_passphrase("\n# passphrase> ").await?
     };
 
-    if let Some(passphrase) = passphrase {
-        server.run_unlocked(passphrase).await?;
-    } else {
-        server.run_locked().await?;
-    }
+    server.run(passphrase).await?;
 
     // if we made it this far, the server is running...
     // we want it to run forever, so this future never resolves:

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/main.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/main.rs
@@ -91,13 +91,6 @@ pub(crate) struct OptServer {
     /// how you make use of this, as it could be less secure.
     #[structopt(short = "p", long, verbatim_doc_comment)]
     pub piped: bool,
-
-    /// Instead of the normal "interactive" method of passphrase
-    /// retreival, start the keystore in "locked" mode. The
-    /// keystore will need to be "unlocked" via some other method
-    /// before it can begin processing requests.
-    #[structopt(short = "l", long, verbatim_doc_comment)]
-    pub locked: bool,
 }
 
 #[derive(Debug, StructOpt)]

--- a/crates/lair_keystore/src/server_test.rs
+++ b/crates/lair_keystore/src/server_test.rs
@@ -22,7 +22,7 @@ async fn server_test_happy_path() {
     crate::server::StandaloneServer::new(config.clone())
         .await
         .unwrap()
-        .run_unlocked(passphrase.clone())
+        .run(passphrase.clone())
         .await
         .unwrap();
 

--- a/crates/lair_keystore_api/Cargo.toml
+++ b/crates/lair_keystore_api/Cargo.toml
@@ -24,7 +24,7 @@ rmp-serde = "0.15.5"
 serde = { version = "1", features = [ "rc" ] }
 serde_bytes = "0.11.5"
 serde_yaml = "0.8.21"
-sodoken = "=0.0.1-alpha.18"
+sodoken = "=0.0.1-alpha.20"
 tokio = { version = "1.12.0", features = [ "full" ] }
 toml = "0.5.8"
 tracing = "0.1.28"

--- a/crates/lair_keystore_api/src/in_proc_keystore.rs
+++ b/crates/lair_keystore_api/src/in_proc_keystore.rs
@@ -33,12 +33,9 @@ impl InProcKeystore {
                 "lair-keystore-in-proc".into(),
                 crate::LAIR_VER.into(),
                 store_factory,
+                passphrase.clone(),
             )
             .await?;
-
-            // with an in-process store, there's no reason not to unlock
-            // it directly while creating the task
-            srv_hnd.unlock(passphrase.clone()).await?;
 
             Ok(Self {
                 config,
@@ -85,7 +82,9 @@ impl InProcKeystore {
             // get the client wrap future
             let cli_fut =
                 crate::lair_client::async_io::new_async_io_lair_client(
-                    cli_send, cli_recv,
+                    cli_send,
+                    cli_recv,
+                    srv_pub_key.cloned_inner().into(),
                 );
 
             // await both futures at the same time so they can

--- a/crates/lair_keystore_api/src/lair_api/hello.rs
+++ b/crates/lair_keystore_api/src/lair_api/hello.rs
@@ -6,17 +6,13 @@ use super::*;
 pub struct LairApiReqHello {
     /// msg id to relate request / response.
     pub msg_id: Arc<str>,
-
-    /// random data for server identity verification.
-    pub nonce: BinData,
 }
 
 impl LairApiReqHello {
     /// Make a new server info request
-    pub fn new(nonce: BinData) -> Self {
+    pub fn new() -> Self {
         Self {
             msg_id: new_msg_id(),
-            nonce,
         }
     }
 }
@@ -53,11 +49,8 @@ pub struct LairApiResHello {
     /// The server semantic version.
     pub version: Arc<str>,
 
-    /// The public key this hello sig was signed with.
+    /// The public key identifying this server.
     pub server_pub_key: BinDataSized<32>,
-
-    /// The hello signature of the random bytes sent with the hello request.
-    pub hello_sig: BinDataSized<64>,
 }
 
 impl std::convert::TryFrom<LairApiEnum> for LairApiResHello {

--- a/crates/lair_keystore_api/src/lair_client/async_io.rs
+++ b/crates/lair_keystore_api/src/lair_client/async_io.rs
@@ -6,6 +6,7 @@ use super::*;
 pub fn new_async_io_lair_client<S, R>(
     send: S,
     recv: R,
+    srv_id_pub_key: sodoken::BufReadSized<32>,
 ) -> impl Future<Output = LairResult<LairClient>> + 'static + Send
 where
     S: tokio::io::AsyncWrite + 'static + Send + Unpin,
@@ -13,11 +14,12 @@ where
 {
     async move {
         // wrap the channels in sodium_secretstream
-        let (send, recv) =
-            crate::sodium_secretstream::new_s3_pair::<LairApiEnum, _, _>(
-                send, recv, false,
-            )
-            .await?;
+        let (send, recv) = crate::sodium_secretstream::new_s3_client::<
+            LairApiEnum,
+            _,
+            _,
+        >(send, recv, srv_id_pub_key)
+        .await?;
 
         // derive our encryption (to server) secret context key
         let enc_ctx_key = <sodoken::BufWriteSized<32>>::new_mem_locked()?;

--- a/crates/lair_keystore_api/src/lair_server/priv_api.rs
+++ b/crates/lair_keystore_api/src/lair_server/priv_api.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub(crate) fn priv_req_hello<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     send: &'a crate::sodium_secretstream::S3Sender<LairApiEnum>,
     req: LairApiReqHello,
 ) -> impl Future<Output = LairResult<()>> + 'a + Send {
@@ -10,28 +10,16 @@ pub(crate) fn priv_req_hello<'a>(
         // we want to be able to verify the server,
         // before we unlock the individual connection.
 
-        let (sign_pk, sign_sk, server_name, server_version) =
-            match &*inner.read() {
-                SrvInnerEnum::Running(p) => (
-                    p.sign_pk.clone(),
-                    p.sign_sk.clone(),
-                    p.server_name.clone(),
-                    p.server_version.clone(),
-                ),
-                SrvInnerEnum::Pending(_) => {
-                    return Err("KeystoreLocked".into());
-                }
-            };
+        let (id_pk, server_name, server_version) = {
+            let lock = inner.read();
+            (
+                lock.id_pk.clone(),
+                lock.server_name.clone(),
+                lock.server_version.clone(),
+            )
+        };
 
-        // sign the incoming nonce
-        let hello_sig = sodoken::BufWriteSized::new_no_lock();
-        sodoken::sign::detached(
-            hello_sig.clone(),
-            req.nonce.cloned_inner(),
-            sign_sk,
-        )
-        .await?;
-        let hello_sig = hello_sig.try_unwrap_sized().unwrap().into();
+        let server_pub_key = (*id_pk.read_lock_sized()).into();
 
         // send our hello response
         send.send(
@@ -39,8 +27,7 @@ pub(crate) fn priv_req_hello<'a>(
                 msg_id: req.msg_id,
                 name: server_name,
                 version: server_version,
-                server_pub_key: sign_pk,
-                hello_sig,
+                server_pub_key,
             }
             .into_api_enum(),
         )
@@ -51,7 +38,7 @@ pub(crate) fn priv_req_hello<'a>(
 }
 
 pub(crate) fn priv_req_unlock<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     send: &'a crate::sodium_secretstream::S3Sender<LairApiEnum>,
     dec_ctx_key: &'a sodoken::BufReadSized<32>,
     unlocked: &'a Arc<atomic::AtomicBool>,
@@ -60,8 +47,55 @@ pub(crate) fn priv_req_unlock<'a>(
     async move {
         let passphrase = req.passphrase.decrypt(dec_ctx_key.clone()).await?;
 
-        // performe the internal state-level unlock process
-        priv_srv_unlock(inner.clone(), passphrase).await?;
+        let (config, id_pk) = {
+            let lock = inner.read();
+            (lock.config.clone(), lock.id_pk.clone())
+        };
+
+        // read salt from config
+        let salt = sodoken::BufReadSized::from(
+            config.runtime_secrets_salt.cloned_inner(),
+        );
+
+        // read limits from config
+        let ops_limit = config.runtime_secrets_ops_limit;
+        let mem_limit = config.runtime_secrets_mem_limit;
+
+        // calculate pre_secret from argon2id passphrase hash
+        let pre_secret = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+        sodoken::hash::argon2id::hash(
+            pre_secret.clone(),
+            passphrase,
+            salt,
+            ops_limit,
+            mem_limit,
+        )
+        .await?;
+
+        // derive signature decryption secret
+        let id_secret = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+        sodoken::kdf::derive_from_key(
+            id_secret.clone(),
+            142,
+            *b"IdnSecKy",
+            pre_secret,
+        )?;
+
+        // decrypt the signature seed
+        let id_seed = config
+            .runtime_secrets_id_seed
+            .decrypt(id_secret.to_read_sized())
+            .await?;
+
+        // derive the signature keypair from the signature seed
+        let d_id_pk = <sodoken::BufWriteSized<32>>::new_no_lock();
+        let d_id_sk = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+        use sodoken::crypto_box::curve25519xchacha20poly1305::*;
+        seed_keypair(d_id_pk.clone(), d_id_sk, id_seed).await?;
+
+        if *id_pk.read_lock() != *d_id_pk.read_lock() {
+            return Err("InvalidPassphrase".into());
+        }
 
         // if that was successfull, we can also set the connection level
         // unlock state to unlocked
@@ -76,7 +110,7 @@ pub(crate) fn priv_req_unlock<'a>(
 }
 
 pub(crate) fn priv_req_get_entry<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     send: &'a crate::sodium_secretstream::S3Sender<LairApiEnum>,
     unlocked: &'a Arc<atomic::AtomicBool>,
     req: LairApiReqGetEntry,
@@ -127,7 +161,7 @@ pub(crate) fn priv_req_get_entry<'a>(
 }
 
 pub(crate) fn priv_req_list_entries<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     send: &'a crate::sodium_secretstream::S3Sender<LairApiEnum>,
     unlocked: &'a Arc<atomic::AtomicBool>,
     req: LairApiReqListEntries,
@@ -153,7 +187,7 @@ pub(crate) fn priv_req_list_entries<'a>(
 }
 
 pub(crate) fn priv_req_new_seed<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     send: &'a crate::sodium_secretstream::S3Sender<LairApiEnum>,
     dec_ctx_key: &'a sodoken::BufReadSized<32>,
     unlocked: &'a Arc<atomic::AtomicBool>,
@@ -198,7 +232,7 @@ pub(crate) fn priv_req_new_seed<'a>(
 }
 
 pub(crate) fn priv_req_sign_by_pub_key<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     send: &'a crate::sodium_secretstream::S3Sender<LairApiEnum>,
     _dec_ctx_key: &'a sodoken::BufReadSized<32>,
     unlocked: &'a Arc<atomic::AtomicBool>,
@@ -237,7 +271,7 @@ pub(crate) fn priv_req_sign_by_pub_key<'a>(
 }
 
 pub(crate) fn priv_req_new_wka_tls_cert<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     send: &'a crate::sodium_secretstream::S3Sender<LairApiEnum>,
     unlocked: &'a Arc<atomic::AtomicBool>,
     req: LairApiReqNewWkaTlsCert,
@@ -263,7 +297,7 @@ pub(crate) fn priv_req_new_wka_tls_cert<'a>(
 }
 
 pub(crate) fn priv_gen_and_register_entry<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     store: &'a LairStore,
     entry: LairEntry,
 ) -> impl Future<Output = LairResult<FullLairEntry>> + 'a + Send {
@@ -287,7 +321,7 @@ pub(crate) fn priv_gen_and_register_entry<'a>(
                 // get the encryption keypair
                 let x_pk = sodoken::BufWriteSized::new_no_lock();
                 let x_sk = sodoken::BufWriteSized::new_mem_locked()?;
-                sodoken::sealed_box::curve25519xchacha20poly1305::seed_keypair(
+                sodoken::crypto_box::curve25519xchacha20poly1305::seed_keypair(
                     x_pk.clone(),
                     x_sk.clone(),
                     seed,
@@ -306,21 +340,16 @@ pub(crate) fn priv_gen_and_register_entry<'a>(
 
         let full_entry = FullLairEntry { entry, ed_sk, x_sk };
 
-        match &mut *inner.write() {
-            SrvInnerEnum::Running(p) => {
-                // add full entry to our LRU caches
-                p.entries_by_tag
-                    .put(full_entry.entry.tag(), full_entry.clone());
-                if let Some(ed_pk) = ed_pk {
-                    p.entries_by_ed.put(ed_pk, full_entry.clone());
-                }
-                if let Some(x_pk) = x_pk {
-                    p.entries_by_x.put(x_pk, full_entry.clone());
-                }
-            }
-            SrvInnerEnum::Pending(_) => {
-                return Err("KeystoreLocked".into());
-            }
+        let mut lock = inner.write();
+
+        // add full entry to our LRU caches
+        lock.entries_by_tag
+            .put(full_entry.entry.tag(), full_entry.clone());
+        if let Some(ed_pk) = ed_pk {
+            lock.entries_by_ed.put(ed_pk, full_entry.clone());
+        }
+        if let Some(x_pk) = x_pk {
+            lock.entries_by_x.put(x_pk, full_entry.clone());
         }
 
         Ok(full_entry)
@@ -329,21 +358,17 @@ pub(crate) fn priv_gen_and_register_entry<'a>(
 
 #[allow(clippy::needless_lifetimes)] // this helps me define the future bounds
 pub(crate) fn priv_get_full_entry_by_tag<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     tag: Arc<str>,
 ) -> impl Future<Output = LairResult<(FullLairEntry, LairStore)>> + 'a + Send {
     async move {
-        let store = match &mut *inner.write() {
-            SrvInnerEnum::Running(p) => {
-                let store = p.store.clone();
-                if let Some(full_entry) = p.entries_by_tag.get(&tag) {
-                    return Ok((full_entry.clone(), store));
-                }
-                store
+        let store = {
+            let mut lock = inner.write();
+            let store = lock.store.clone();
+            if let Some(full_entry) = lock.entries_by_tag.get(&tag) {
+                return Ok((full_entry.clone(), store));
             }
-            SrvInnerEnum::Pending(_) => {
-                return Err("KeystoreLocked".into());
-            }
+            store
         };
 
         // get the entry
@@ -358,21 +383,17 @@ pub(crate) fn priv_get_full_entry_by_tag<'a>(
 
 #[allow(clippy::needless_lifetimes)] // this helps me define the future bounds
 pub(crate) fn priv_get_full_entry_by_ed_pub_key<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     ed_pub_key: Ed25519PubKey,
 ) -> impl Future<Output = LairResult<(FullLairEntry, LairStore)>> + 'a + Send {
     async move {
-        let store = match &mut *inner.write() {
-            SrvInnerEnum::Running(p) => {
-                let store = p.store.clone();
-                if let Some(full_entry) = p.entries_by_ed.get(&ed_pub_key) {
-                    return Ok((full_entry.clone(), store));
-                }
-                store
+        let store = {
+            let mut lock = inner.write();
+            let store = lock.store.clone();
+            if let Some(full_entry) = lock.entries_by_ed.get(&ed_pub_key) {
+                return Ok((full_entry.clone(), store));
             }
-            SrvInnerEnum::Pending(_) => {
-                return Err("KeystoreLocked".into());
-            }
+            store
         };
 
         // get the entry
@@ -386,7 +407,7 @@ pub(crate) fn priv_get_full_entry_by_ed_pub_key<'a>(
 }
 
 pub(crate) fn priv_req_get_wka_tls_cert_priv_key<'a>(
-    inner: &'a Arc<RwLock<SrvInnerEnum>>,
+    inner: &'a Arc<RwLock<SrvInner>>,
     send: &'a crate::sodium_secretstream::S3Sender<LairApiEnum>,
     enc_ctx_key: &'a sodoken::BufReadSized<32>,
     unlocked: &'a Arc<atomic::AtomicBool>,

--- a/crates/lair_keystore_api/src/lair_store.rs
+++ b/crates/lair_keystore_api/src/lair_store.rs
@@ -222,7 +222,7 @@ impl LairStore {
             // derive the x25519 encryption keypair from this seed
             let x_pk = sodoken::BufWriteSized::new_no_lock();
             let x_sk = sodoken::BufWriteSized::new_mem_locked()?;
-            sodoken::sealed_box::curve25519xchacha20poly1305::seed_keypair(
+            sodoken::crypto_box::curve25519xchacha20poly1305::seed_keypair(
                 x_pk.clone(),
                 x_sk,
                 seed.clone(),
@@ -282,7 +282,7 @@ impl LairStore {
             // derive the x25519 encryption keypair from this seed
             let x_pk = sodoken::BufWriteSized::new_no_lock();
             let x_sk = sodoken::BufWriteSized::new_mem_locked()?;
-            sodoken::sealed_box::curve25519xchacha20poly1305::seed_keypair(
+            sodoken::crypto_box::curve25519xchacha20poly1305::seed_keypair(
                 x_pk.clone(),
                 x_sk,
                 seed.clone(),


### PR DESCRIPTION
DEPENDS ON https://github.com/holochain/lair/pull/70

- The concept of starting a keystore "locked" and waiting for a client connection unlock it was flawed.
- The concept of using signatures to verify server identity was flawed.

Removes the "locked" concept, and uses encryption pub key to identify the server so a MitM can't just forward the nonce / signature.