### PR TITLE
[new-lair-13] signature_fallback hook for Holo integration

### DIFF
--- a/.github/workflows/ops.test.yml
+++ b/.github/workflows/ops.test.yml
@@ -38,6 +38,24 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
+      - name: Cargo Build
+        uses: actions-rs/cargo@v1
+        env:
+          RUST_BACKTRACE: 1
+        with:
+          command: build
+          args:
+
+      - name: Cargo Targets
+        uses: actions-rs/cargo@v1
+        env:
+          RUST_BACKTRACE: 1
+        with:
+          command: test
+          args:
+            - --all-targets
+            - --no-run
+
       - name: Cargo Test
         uses: actions-rs/cargo@v1
         env:

--- a/.github/workflows/ops.test.yml
+++ b/.github/workflows/ops.test.yml
@@ -52,9 +52,7 @@ jobs:
           RUST_BACKTRACE: 1
         with:
           command: test
-          args:
-            - --all-targets
-            - --no-run
+          args: --all-targets --no-run
 
       - name: Cargo Test
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b800c4403e8105d959595e1f88119e78bc12bc874c4336973658b648a746ba93"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +259,18 @@ checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
@@ -536,7 +562,9 @@ dependencies = [
 name = "lair_keystore_api"
 version = "0.1.0-alpha.1"
 dependencies = [
+ "assert_cmd",
  "base64",
+ "dunce",
  "futures",
  "hc_seed_bundle",
  "lru",
@@ -844,6 +872,33 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "predicates"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c143348f141cc87aab5b950021bac6145d0e5ae754b0591de23244cee42c9308"
+dependencies = [
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dd0fd014130206c9352efbdc92be592751b2b9274dff685348341082c6ea3d"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -1205,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1503,6 +1558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1632,15 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ test: tools
 	if [ "${CI}x" != "x" ]; then \
 		$(ENV) cargo install --debug -f --path crates/lair_keystore; \
 	fi
+	$(ENV) RUST_BACKTRACE=1 cargo build
 	$(ENV) RUST_BACKTRACE=1 cargo test --all-targets --no-run
 	$(ENV) RUST_BACKTRACE=1 cargo test
 	$(ENV) cargo readme -r crates/hc_seed_bundle -o README.md

--- a/crates/lair_keystore_api/Cargo.toml
+++ b/crates/lair_keystore_api/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13.0"
+dunce = "1.0.2"
 futures = "0.3.17"
 hc_seed_bundle = { version = "=0.1.0-alpha.1", path = "../hc_seed_bundle" }
 lru = "0.6.6"
@@ -23,6 +24,7 @@ rcgen = "0.8.13"
 rmp-serde = "0.15.5"
 serde = { version = "1", features = [ "rc" ] }
 serde_bytes = "0.11.5"
+serde_json = "1.0.68"
 serde_yaml = "0.8.21"
 sodoken = "=0.0.1-alpha.20"
 tokio = { version = "1.12.0", features = [ "full" ] }
@@ -34,7 +36,7 @@ url = { version = "2.2.2", features = [ "serde" ] }
 winapi = "0.3.9"
 
 [dev-dependencies]
-serde_json = "1"
+assert_cmd = "2.0.1"
 tempdir = "0.3.7"
 tracing-subscriber = "0.2.24"
 

--- a/crates/lair_keystore_api/src/bin/fixture-sig-fallback.rs
+++ b/crates/lair_keystore_api/src/bin/fixture-sig-fallback.rs
@@ -1,11 +1,21 @@
+//! fixture executable to be used in signature_fallback testing
+//! This binary listens to stdin for newline delimited json signature requests
+//! and alternates between "success" and "error" responses.
+//! It doesn't do any actual signing, it always returns an all zeroes sig.
+
 fn main() {
     use std::io::BufRead;
 
+    // alternate between good and bad responses
     let mut bad = false;
 
+    // using blocking reading -- if you were actually implementing this
+    // it'd probably be better to use tokio::io::AsyncBufReadExt::lines()
     let stdin = std::io::stdin();
     for line in stdin.lock().lines() {
         let line = line.unwrap();
+
+        // parse the msg_id out of the json
         let parsed: serde_json::Value = serde_json::from_str(&line).unwrap();
         let msg_id = parsed
             .as_object()
@@ -14,6 +24,8 @@ fn main() {
             .unwrap()
             .as_str()
             .unwrap();
+
+        // send the signature response
         if bad {
             bad = false;
             println!(r#"{{"msgId":"{}","error":"internal"}}"#, msg_id);

--- a/crates/lair_keystore_api/src/bin/fixture-sig-fallback.rs
+++ b/crates/lair_keystore_api/src/bin/fixture-sig-fallback.rs
@@ -1,0 +1,28 @@
+fn main() {
+    use std::io::BufRead;
+
+    let mut bad = false;
+
+    let stdin = std::io::stdin();
+    for line in stdin.lock().lines() {
+        let line = line.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&line).unwrap();
+        let msg_id = parsed
+            .as_object()
+            .unwrap()
+            .get("msgId")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        if bad {
+            bad = false;
+            println!(r#"{{"msgId":"{}","error":"internal"}}"#, msg_id);
+        } else {
+            bad = true;
+            println!(
+                r#"{{"msgId":"{}","signature":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="}}"#,
+                msg_id
+            );
+        }
+    }
+}

--- a/crates/lair_keystore_api/src/config.rs
+++ b/crates/lair_keystore_api/src/config.rs
@@ -67,6 +67,8 @@ pub struct LairServerConfigInner {
 impl std::fmt::Display for LairServerConfigInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = serde_yaml::to_string(&self).map_err(|_| std::fmt::Error)?;
+
+        // inject some helpful comments
         let mut lines = Vec::new();
         for (id, line) in s.split('\n').enumerate() {
             if id > 0 {

--- a/crates/lair_keystore_api/src/config.rs
+++ b/crates/lair_keystore_api/src/config.rs
@@ -4,6 +4,29 @@ use crate::prelude::*;
 use std::future::Future;
 use std::sync::Arc;
 
+/// Enum for configuring signature fallback handling
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub enum LairServerSignatureFallback {
+    /// No fallback handling. If a pub key does not exist
+    /// in the lair store, a sign_by_pub_key request will error.
+    None,
+
+    /// Specify a command to execute on lair server start.
+    /// This command will be fed framed json signature requests on stdin,
+    /// and is expected to respond to those requests with framed
+    /// json responses on stdout.
+    #[serde(rename_all = "camelCase")]
+    Command {
+        /// The program command to execute.
+        program: std::path::PathBuf,
+
+        /// Optional arguments to be passed to command on execute.
+        args: Option<Vec<String>>,
+    },
+}
+
 /// Config used by lair servers.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -20,6 +43,10 @@ pub struct LairServerConfigInner {
 
     /// The sqlcipher store file for persisting secrets
     pub store_file: std::path::PathBuf,
+
+    /// Configuration for managing sign_by_pub_key fallback
+    /// in case the pub key does not exist in the lair store.
+    pub signature_fallback: LairServerSignatureFallback,
 
     /// salt for decrypting runtime data
     pub runtime_secrets_salt: BinDataSized<16>,
@@ -40,7 +67,52 @@ pub struct LairServerConfigInner {
 impl std::fmt::Display for LairServerConfigInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = serde_yaml::to_string(&self).map_err(|_| std::fmt::Error)?;
-        f.write_str(&s)
+        let mut lines = Vec::new();
+        for (id, line) in s.split('\n').enumerate() {
+            if id > 0 {
+                if line.starts_with("connectionUrl:") {
+                    lines.push("");
+                    lines.push("# The connection url for communications between server / client.");
+                    lines.push("# - `unix:///path/to/unix/socket?k=Yada`");
+                    lines.push(
+                        "# - `named_pipe:\\\\.\\pipe\\my_pipe_name?k=Yada`",
+                    );
+                    lines.push("# - (not yet supported) `tcp://127.0.0.1:12345?k=Yada`");
+                } else if line.starts_with("pidFile:") {
+                    lines.push("");
+                    lines.push("# The pid file for managing a running lair-keystore process");
+                } else if line.starts_with("storeFile:") {
+                    lines.push("");
+                    lines.push(
+                        "# The sqlcipher store file for persisting secrets",
+                    );
+                } else if line.starts_with("signatureFallback:") {
+                    lines.push("");
+                    lines.push(
+                        "# Configuration for managing sign_by_pub_key fallback",
+                    );
+                    lines.push("# in case the pub key does not exist in the lair store.");
+                    lines.push("# - `signatureFallback: none`");
+                    lines.push("# - ```");
+                    lines.push("#   signatureFallback:");
+                    lines.push("#     command:");
+                    lines.push("#       # 'program' will resolve to a path, specifying 'echo'");
+                    lines.push("#       # will try to run './echo', probably not what you want.");
+                    lines.push("#       program: \"./my-executable\"");
+                    lines.push("#       # args are optional");
+                    lines.push("#       args:");
+                    lines.push("#         - test-arg1");
+                    lines.push("#         - test-arg2");
+                    lines.push("#   ```");
+                } else if line.starts_with("runtimeSecretsSalt:") {
+                    lines.push("");
+                    lines.push("# -- cryptographic secrets --");
+                    lines.push("# If you modify the data below, you risk loosing access to your keys.");
+                }
+            }
+            lines.push(line);
+        }
+        f.write_str(&lines.join("\n"))
     }
 }
 
@@ -171,6 +243,7 @@ impl LairServerConfigInner {
                 connection_url,
                 pid_file,
                 store_file,
+                signature_fallback: LairServerSignatureFallback::None,
                 runtime_secrets_salt: salt.try_unwrap_sized().unwrap().into(),
                 runtime_secrets_mem_limit: mem_limit,
                 runtime_secrets_ops_limit: ops_limit,
@@ -233,18 +306,28 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_config_yaml() {
         let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
-        let srv = hc_seed_bundle::PwHashLimits::Interactive
+        let mut srv = hc_seed_bundle::PwHashLimits::Interactive
             .with_exec(|| {
                 LairServerConfigInner::new("/tmp/my/path", passphrase)
             })
             .await
             .unwrap();
+
         println!("-- server config start --");
-        println!("{}", serde_yaml::to_string(&srv).unwrap());
+        println!("{}", &srv);
         println!("-- server config end --");
         assert_eq!(
             std::path::PathBuf::from("/tmp/my/path").as_path(),
             srv.pid_file.parent().unwrap(),
         );
+
+        srv.signature_fallback = LairServerSignatureFallback::Command {
+            program: std::path::Path::new("./my-executable").into(),
+            args: Some(vec!["test-arg1".into(), "test-arg2".into()]),
+        };
+
+        println!("-- server config start --");
+        println!("{}", &srv);
+        println!("-- server config end --");
     }
 }

--- a/crates/lair_keystore_api/src/lair_server.rs
+++ b/crates/lair_keystore_api/src/lair_server.rs
@@ -131,7 +131,7 @@ impl FallbackCmd {
             .kill_on_drop(true)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
+            .stderr(std::process::Stdio::inherit())
             .spawn()?;
 
         // get our pipe handles


### PR DESCRIPTION
DEPENDS ON: https://github.com/holochain/lair/pull/71

[Video Walkthrough (2:46)](https://www.youtube.com/watch?v=axcQ63RojWE)

Allows specifying a signatureFallback executable in the lair server config:

```yaml
signatureFallback: none
```

or

```yaml
signatureFallback:
  command:
    # 'program' will resolve to a path, specifying 'echo'
    # will try to run './echo', probably not what you want.
    program: "./my-executable"
    # args are optional
    args:
      - test-arg1
      - test-arg2
```

which will read newline delimited json requests on stdin like:

```json
{"msgId":"k9PRhnExjFK_K_kOiHT3k","pubKey":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","dataToSign":"aGVsbG8="}
```

and is expected to respond with newline delimited responses on stdout like:

```json
{"msgId":"k9PRhnExjFK_K_kOiHT3k","signature":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="}
```

or

```json
{"msgId":"6ZV-yeU3DOJ6oNOENjdTU","error":"internal"}
```