### PR TITLE
fixes #103 just by providing a useful failure message

### DIFF
--- a/crates/lair_keystore_api/src/config.rs
+++ b/crates/lair_keystore_api/src/config.rs
@@ -292,7 +292,9 @@ pub fn get_connection_path(url: &url::Url) -> std::path::PathBuf {
 
     #[cfg(not(windows))]
     {
-        url.to_file_path().expect("can decode as file path")
+        url.to_file_path().expect("The connection url is invalid, as it does not decode to
+an absolute file path. The likely cause is that a relative path was used instead of an absolute one.
+If that's the case, try using an absolute one instead.")
     }
 }
 


### PR DESCRIPTION
I thought in any case this error message could be more useful. There might be various folks spinning up lair keystore processes decoupled from holochain, and they might run into it.