### PR TITLE
Fix compile with winapi for Windows

### DIFF
--- a/crates/lair_keystore_api/Cargo.toml
+++ b/crates/lair_keystore_api/Cargo.toml
@@ -31,7 +31,7 @@ url = { version = "2.3.1", features = [ "serde" ] }
 zeroize = "1.6.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3.9"
+winapi = { version = "0.3.9", features = ["winerror"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.11"


### PR DESCRIPTION
We were relying on one of our dependencies (socket2? possibly, not sure) enabling a feature on `winapi` that we relied on. That is no longer the case. Just adding in the feature flag that gives us the module we need.