### PR TITLE
fix: use absolute path for unix socket in connection_url 

### DIFF
--- a/crates/lair_keystore_api/src/config.rs
+++ b/crates/lair_keystore_api/src/config.rs
@@ -238,7 +238,7 @@ impl LairServerConfigInner {
             // on not-windows, we default to using unix domain sockets
             #[cfg(not(windows))]
             let connection_url = {
-                let mut con_path = root_path.clone();
+                let mut con_path = root_path.clone().canonicalize().unwrap();
                 con_path.push("socket");
                 url::Url::parse(&format!(
                     "unix://{}?k={}",

--- a/crates/lair_keystore_api/src/config.rs
+++ b/crates/lair_keystore_api/src/config.rs
@@ -238,7 +238,7 @@ impl LairServerConfigInner {
             // on not-windows, we default to using unix domain sockets
             #[cfg(not(windows))]
             let connection_url = {
-                let mut con_path = root_path.clone().canonicalize().unwrap();
+                let mut con_path = dunce::canonicalize(root_path)?;
                 con_path.push("socket");
                 url::Url::parse(&format!(
                     "unix://{}?k={}",

--- a/crates/lair_keystore_api/src/config.rs
+++ b/crates/lair_keystore_api/src/config.rs
@@ -322,7 +322,7 @@ mod tests {
         let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
         let mut srv = hc_seed_bundle::PwHashLimits::Minimum
             .with_exec(|| {
-                LairServerConfigInner::new("/tmp/my/path", passphrase)
+                LairServerConfigInner::new("/", passphrase)
             })
             .await
             .unwrap();

--- a/crates/lair_keystore_api/src/config.rs
+++ b/crates/lair_keystore_api/src/config.rs
@@ -319,10 +319,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_config_yaml() {
+        let tempdir = tempdir::TempDir::new("example").unwrap();
         let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
         let mut srv = hc_seed_bundle::PwHashLimits::Minimum
             .with_exec(|| {
-                LairServerConfigInner::new("/", passphrase)
+                LairServerConfigInner::new(tempdir.path(), passphrase)
             })
             .await
             .unwrap();
@@ -331,7 +332,7 @@ mod tests {
         println!("{}", &srv);
         println!("-- server config end --");
         assert_eq!(
-            std::path::PathBuf::from("/tmp/my/path").as_path(),
+            tempdir.path(),
             srv.pid_file.parent().unwrap(),
         );
 

--- a/crates/lair_keystore_api/src/config.rs
+++ b/crates/lair_keystore_api/src/config.rs
@@ -331,10 +331,7 @@ mod tests {
         println!("-- server config start --");
         println!("{}", &srv);
         println!("-- server config end --");
-        assert_eq!(
-            tempdir.path(),
-            srv.pid_file.parent().unwrap(),
-        );
+        assert_eq!(tempdir.path(), srv.pid_file.parent().unwrap(),);
 
         srv.signature_fallback = LairServerSignatureFallback::Command {
             program: std::path::Path::new("./my-executable").into(),

--- a/crates/lair_keystore_api/tests/config.rs
+++ b/crates/lair_keystore_api/tests/config.rs
@@ -4,7 +4,7 @@ use lair_keystore_api::prelude::*;
 
 #[cfg(not(windows))]
 #[tokio::test(flavor = "multi_thread")]
-async fn lair_config_connection_url_absolute() {
+async fn lair_config_connection_url_relative_root() {
     use std::fs::{create_dir, remove_dir};
 
   let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
@@ -19,6 +19,29 @@ async fn lair_config_connection_url_absolute() {
   let mut expected_path: PathBuf = current_dir().unwrap();
   expected_path.push("config-root-path-test");
   let expected_path_str = expected_path.to_str().unwrap();
+
+  assert_eq!(true, config.connection_url.as_str().contains(expected_path_str));
+}
+
+#[cfg(not(windows))]
+#[tokio::test(flavor = "multi_thread")]
+async fn lair_config_connection_url_absolute_root() {
+    use std::fs::{create_dir, remove_dir};
+
+  let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
+
+  let _ = create_dir("./config-root-path-test");
+  let mut lair_root = current_dir().unwrap();
+  lair_root.push("config-root-path-test");
+  let config = hc_seed_bundle::PwHashLimits::Minimum
+      .with_exec(|| LairServerConfigInner::new(lair_root.clone(), passphrase.clone()))
+      .await
+      .unwrap();
+  let _ = remove_dir("./config-root-path-test");
+
+  let mut expected_path: PathBuf = current_dir().unwrap();
+  expected_path.push("config-root-path-test");
+  let expected_path_str = lair_root.to_str().unwrap();
 
   assert_eq!(true, config.connection_url.as_str().contains(expected_path_str));
 }

--- a/crates/lair_keystore_api/tests/config.rs
+++ b/crates/lair_keystore_api/tests/config.rs
@@ -1,26 +1,34 @@
-use std::{env::current_dir, path::PathBuf};
 use hc_seed_bundle::dependencies::sodoken;
 use lair_keystore_api::prelude::*;
+use std::{env::current_dir, path::PathBuf};
 
 #[cfg(not(windows))]
 #[tokio::test(flavor = "multi_thread")]
 async fn lair_config_connection_url_relative_root() {
     use std::fs::{create_dir, remove_dir};
 
-  let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
+    let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
 
-  let _ = create_dir("./config-root-path-test");
-  let config = hc_seed_bundle::PwHashLimits::Minimum
-      .with_exec(|| LairServerConfigInner::new("./config-root-path-test", passphrase.clone()))
-      .await
-      .unwrap();
-  let _ = remove_dir("./config-root-path-test");
+    let _ = create_dir("./config-root-path-test");
+    let config = hc_seed_bundle::PwHashLimits::Minimum
+        .with_exec(|| {
+            LairServerConfigInner::new(
+                "./config-root-path-test",
+                passphrase.clone(),
+            )
+        })
+        .await
+        .unwrap();
+    let _ = remove_dir("./config-root-path-test");
 
-  let mut expected_path: PathBuf = current_dir().unwrap();
-  expected_path.push("config-root-path-test");
-  let expected_path_str = expected_path.to_str().unwrap();
+    let mut expected_path: PathBuf = current_dir().unwrap();
+    expected_path.push("config-root-path-test");
+    let expected_path_str = expected_path.to_str().unwrap();
 
-  assert_eq!(true, config.connection_url.as_str().contains(expected_path_str));
+    assert_eq!(
+        true,
+        config.connection_url.as_str().contains(expected_path_str)
+    );
 }
 
 #[cfg(not(windows))]
@@ -28,20 +36,25 @@ async fn lair_config_connection_url_relative_root() {
 async fn lair_config_connection_url_absolute_root() {
     use std::fs::{create_dir, remove_dir};
 
-  let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
+    let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
 
-  let _ = create_dir("./config-root-path-test");
-  let mut lair_root = current_dir().unwrap();
-  lair_root.push("config-root-path-test");
-  let config = hc_seed_bundle::PwHashLimits::Minimum
-      .with_exec(|| LairServerConfigInner::new(lair_root.clone(), passphrase.clone()))
-      .await
-      .unwrap();
-  let _ = remove_dir("./config-root-path-test");
+    let _ = create_dir("./config-root-path-test");
+    let mut lair_root = current_dir().unwrap();
+    lair_root.push("config-root-path-test");
+    let config = hc_seed_bundle::PwHashLimits::Minimum
+        .with_exec(|| {
+            LairServerConfigInner::new(lair_root.clone(), passphrase.clone())
+        })
+        .await
+        .unwrap();
+    let _ = remove_dir("./config-root-path-test");
 
-  let mut expected_path: PathBuf = current_dir().unwrap();
-  expected_path.push("config-root-path-test");
-  let expected_path_str = lair_root.to_str().unwrap();
+    let mut expected_path: PathBuf = current_dir().unwrap();
+    expected_path.push("config-root-path-test");
+    let expected_path_str = lair_root.to_str().unwrap();
 
-  assert_eq!(true, config.connection_url.as_str().contains(expected_path_str));
+    assert_eq!(
+        true,
+        config.connection_url.as_str().contains(expected_path_str)
+    );
 }

--- a/crates/lair_keystore_api/tests/config.rs
+++ b/crates/lair_keystore_api/tests/config.rs
@@ -18,10 +18,7 @@ async fn lair_config_connection_url_relative_root() {
 
     let config = hc_seed_bundle::PwHashLimits::Minimum
         .with_exec(|| {
-            LairServerConfigInner::new(
-                relative_lair_root,
-                passphrase.clone(),
-            )
+            LairServerConfigInner::new(relative_lair_root, passphrase.clone())
         })
         .await
         .unwrap();
@@ -41,7 +38,7 @@ async fn lair_config_connection_url_relative_root() {
 async fn lair_config_connection_url_absolute_root() {
     // Lair config should use an absolute path for 'connection_url'
     // when passed an absolute path for 'lair_root'
-    
+
     let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
 
     let dir = TempDir::new_in(".", "example").unwrap();
@@ -50,7 +47,10 @@ async fn lair_config_connection_url_absolute_root() {
 
     let config = hc_seed_bundle::PwHashLimits::Minimum
         .with_exec(|| {
-            LairServerConfigInner::new(absolute_lair_root.clone(), passphrase.clone())
+            LairServerConfigInner::new(
+                absolute_lair_root.clone(),
+                passphrase.clone(),
+            )
         })
         .await
         .unwrap();

--- a/crates/lair_keystore_api/tests/config.rs
+++ b/crates/lair_keystore_api/tests/config.rs
@@ -1,0 +1,24 @@
+use std::{env::current_dir, path::PathBuf};
+use hc_seed_bundle::dependencies::sodoken;
+use lair_keystore_api::prelude::*;
+
+#[cfg(not(windows))]
+#[tokio::test(flavor = "multi_thread")]
+async fn lair_config_connection_url_absolute() {
+    use std::fs::{create_dir, remove_dir};
+
+  let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
+
+  let _ = create_dir("./config-root-path-test");
+  let config = hc_seed_bundle::PwHashLimits::Minimum
+      .with_exec(|| LairServerConfigInner::new("./config-root-path-test", passphrase.clone()))
+      .await
+      .unwrap();
+  let _ = remove_dir("./config-root-path-test");
+
+  let mut expected_path: PathBuf = current_dir().unwrap();
+  expected_path.push("config-root-path-test");
+  let expected_path_str = expected_path.to_str().unwrap();
+
+  assert_eq!(true, config.connection_url.as_str().contains(expected_path_str));
+}


### PR DESCRIPTION
When creating a new lair config on unix, ensure the param `connection_url` uses an absolute path to the unix socket.

I think this resolves an issue where `Conductor::builder().build().await` panics when passing in `None`, or a relative path for the config option `keystore.lair_root`, but still need to test.