### PR TITLE
build: pin serde and rmp-serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.1.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
+checksum = "723ecff9ad04f4ad92fe1c8ca6c20d2196d9286e9c60727c4cb5511629260e9d"
 dependencies = [
  "byteorder",
  "rmp",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/hc_seed_bundle/Cargo.toml
+++ b/crates/hc_seed_bundle/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2018"
 [dependencies]
 futures = "0.3.28"
 one_err = "0.0.8"
-rmp-serde = "=0.15.5"
+rmp-serde = "0.15"
 rmpv = { version = "=1.0.0", features = [ "with-serde" ] } # Version 1.0.1 requires Rust 1.70.0
-serde = { version = "=1.0.193", features = [ "derive", "rc" ] }
+serde = { version = "1", features = [ "derive", "rc" ] }
 serde_bytes = "0.11.9"
 sodoken = "=0.0.9"
 

--- a/crates/hc_seed_bundle/Cargo.toml
+++ b/crates/hc_seed_bundle/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2018"
 [dependencies]
 futures = "0.3.28"
 one_err = "0.0.8"
-rmp-serde = "1.1.1"
+rmp-serde = "=0.15.5"
 rmpv = { version = "=1.0.0", features = [ "with-serde" ] } # Version 1.0.1 requires Rust 1.70.0
-serde = { version = "1", features = [ "derive", "rc" ] }
+serde = { version = "=1.0.193", features = [ "derive", "rc" ] }
 serde_bytes = "0.11.9"
 sodoken = "=0.0.9"
 

--- a/crates/lair_keystore/src/store_sqlite.rs
+++ b/crates/lair_keystore/src/store_sqlite.rs
@@ -179,7 +179,7 @@ impl SqlPool {
         // only set WAL mode on the first write connection
         // it's a slow operation, and not needed on subsequent connections.
         write_con
-            .pragma_update(None, "journal_mode", &"WAL".to_string())
+            .pragma_update(None, "journal_mode", "WAL".to_string())
             .map_err(one_err::OneErr::new)?;
 
         // initialize tables if they don't already exist

--- a/crates/lair_keystore/src/store_sqlite.rs
+++ b/crates/lair_keystore/src/store_sqlite.rs
@@ -179,7 +179,7 @@ impl SqlPool {
         // only set WAL mode on the first write connection
         // it's a slow operation, and not needed on subsequent connections.
         write_con
-            .pragma_update(None, "journal_mode", "WAL".to_string())
+            .pragma_update(None, "journal_mode", &"WAL".to_string())
             .map_err(one_err::OneErr::new)?;
 
         // initialize tables if they don't already exist

--- a/crates/lair_keystore_api/Cargo.toml
+++ b/crates/lair_keystore_api/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = "1.17.1"
 parking_lot = "0.12.1"
 rcgen = { version = "0.10.0", features = [ "zeroize" ] }
 time = "=0.3.23" # Pinned to prevent rvgen pulling in ^0.2.25 which doesn't build on Rust 1.66.1
-serde = { version = "=1.0.193", features = [ "derive", "rc" ] }
+serde = { version = "1", features = [ "derive", "rc" ] }
 serde_json = "1"
 serde_yaml = "0.9.21"
 tokio = { version = "1.27.0", features = [ "full" ] }

--- a/crates/lair_keystore_api/Cargo.toml
+++ b/crates/lair_keystore_api/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = "1.17.1"
 parking_lot = "0.12.1"
 rcgen = { version = "0.10.0", features = [ "zeroize" ] }
 time = "=0.3.23" # Pinned to prevent rvgen pulling in ^0.2.25 which doesn't build on Rust 1.66.1
-serde = { version = "1", features = [ "derive", "rc" ] }
+serde = { version = "=1.0.193", features = [ "derive", "rc" ] }
 serde_json = "1"
 serde_yaml = "0.9.21"
 tokio = { version = "1.27.0", features = [ "full" ] }


### PR DESCRIPTION
After the conductor API [breakage due to an interplay between `rmp-serde` and a patch update in `serde`](https://github.com/serde-rs/serde/issues/2662), these two packages are pinned in the Holochain repo. Lair is using a different version of `rmp-serde`, which is why I'd like to match the one in Holochain to prevent serialization problems between Lair and Holochain.