### PR TITLE
Automatically migrate unencrypted databases on request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,28 @@ jobs:
         ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
+
+      - name: Install vcpkg Packages
+        if: matrix.os == 'windows-latest'
+        uses: johnwason/vcpkg-action@v6
+        id: vcpkg
+        with:
+          pkgs: libsodium
+          triplet: x64-windows-release
+          token: ${{ github.token }}
+          github-binarycache: true
+
+      - name: Make Release
+        if: matrix.os == 'windows-latest'
+        run: |-
+          $env:SODIUM_LIB_DIR="$(pwd)\vcpkg\packages\libsodium_x64-windows\lib"
+          make release
 
       - name: Make Release
         run: make release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     name: Release Build
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [
           ubuntu-latest,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,10 @@ jobs:
           token: ${{ github.token }}
           github-binarycache: true
 
-      - name: Make Release
+      - name: Make Release Windows
         if: matrix.os == 'windows-latest'
         run: |-
-          $env:SODIUM_LIB_DIR="$(pwd)\vcpkg\packages\libsodium_x64-windows\lib"
+          $env:SODIUM_LIB_DIR="$(pwd)\vcpkg\packages\libsodium_x64-windows-release\lib"
           make release
 
       - name: Make Release

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,6 +11,7 @@ jobs:
     name: Static Analysis
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [
           ubuntu-latest,

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,7 +22,7 @@ jobs:
         ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,16 +41,10 @@ jobs:
           token: ${{ github.token }}
           github-binarycache: true
 
-      - name: Make Test
+      - name: Make Test Windows
         if: matrix.os == 'windows-latest'
         run: |-
           $env:SODIUM_LIB_DIR="$(pwd)\vcpkg\packages\libsodium_x64-windows-release\lib"
-          ls
-          ls .\vcpkg
-          ls .\vcpkg\packages
-          ls .\vcpkg\packages\libsodium_x64-windows-release
-          ls .\vcpkg\packages\libsodium_x64-windows-release\lib
-          ls $SODIUM_LIB_DIR
           make test
 
       - name: Make Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,13 @@ jobs:
           github-binarycache: true
 
       - name: Make Test
+        if: matrix.os == 'windows-latest'
         env:
           SODIUM_USE_PKG_CONFIG: "true"
+        run: |-
+          SODIUM_LIB_DIR=${{ steps.vcpkg.outputs.lib_dir }}
+          make test
+
+      - name: Make Test
+        if: matrix.os != 'windows-latest'
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Make Test
+        env:
+          SODIUM_USE_PKG_CONFIG: "true"
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,16 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
+      - name: vcpkg build
+        if: matrix.os == 'windows-latest'
+        uses: johnwason/vcpkg-action@v6
+        id: vcpkg
+        with:
+          pkgs: libsodium
+          triplet: x64-windows-release
+          token: ${{ github.token }}
+          github-binarycache: true
+
       - name: Make Test
         env:
           SODIUM_USE_PKG_CONFIG: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
         run: |-
           $env:SODIUM_LIB_DIR="$(pwd)\vcpkg\packages\libsodium_x64-windows\lib"
           ls
+          ls .\vcpkg
+          ls .\vcpkg\packages
+          ls .\vcpkg\packages\libsodium_x64-windows
+          ls .\vcpkg\packages\libsodium_x64-windows\lib
           ls $SODIUM_LIB_DIR
           make test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,14 @@ jobs:
         ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
 
-      - name: vcpkg build
+      - name: Install vcpkg Packages
         if: matrix.os == 'windows-latest'
         uses: johnwason/vcpkg-action@v6
         id: vcpkg
@@ -45,6 +45,8 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |-
           $env:SODIUM_LIB_DIR="$(pwd)\vcpkg\packages\libsodium_x64-windows\lib"
+          ls
+          ls $SODIUM_LIB_DIR
           make test
 
       - name: Make Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           SODIUM_USE_PKG_CONFIG: "true"
         run: |-
-          SODIUM_LIB_DIR=${{ steps.vcpkg.outputs.lib_dir }}
+          $env:SODIUM_LIB_DIR="$(pwd)\packages\libsodium_x64-windows\lib"
           make test
 
       - name: Make Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [
           ubuntu-latest,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Make Test
         if: matrix.os == 'windows-latest'
         run: |-
-          $env:SODIUM_LIB_DIR="$(pwd)\vcpkg\packages\libsodium_x64-windows\lib"
+          $env:SODIUM_LIB_DIR="$(pwd)\vcpkg\packages\libsodium_x64-windows-release\lib"
           ls
           ls .\vcpkg
           ls .\vcpkg\packages
-          ls .\vcpkg\packages\libsodium_x64-windows
-          ls .\vcpkg\packages\libsodium_x64-windows\lib
+          ls .\vcpkg\packages\libsodium_x64-windows-release
+          ls .\vcpkg\packages\libsodium_x64-windows-release\lib
           ls $SODIUM_LIB_DIR
           make test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,8 @@ jobs:
 
       - name: Make Test
         if: matrix.os == 'windows-latest'
-        env:
-          SODIUM_USE_PKG_CONFIG: "true"
         run: |-
-          $env:SODIUM_LIB_DIR="$(pwd)\packages\libsodium_x64-windows\lib"
+          $env:SODIUM_LIB_DIR="$(pwd)\vcpkg\packages\libsodium_x64-windows\lib"
           make test
 
       - name: Make Test

--- a/crates/lair_keystore/CHANGELOG.md
+++ b/crates/lair_keystore/CHANGELOG.md
@@ -1,1 +1,9 @@
+## 0.4.1
+
+- Add a way to migrate unencrypted databases to encrypted by providing an environment variable `LAIR_MIGRATE_UNENCRYPTED="true"`, Lair will detect databases which can't be opened and attempt migration. #121
+
+# 0.4.0
+
+- pin serde and rmp-serde #119
+
 ## 0.0.2

--- a/crates/lair_keystore/src/lib.rs
+++ b/crates/lair_keystore/src/lib.rs
@@ -54,6 +54,8 @@ include!(concat!(env!("OUT_DIR"), "/ver.rs"));
 
 /// Re-exported dependencies.
 pub mod dependencies {
+    // Not sure why Clippy picks this up as unused, it's exported to be used elsewhere
+    #[allow(unused_imports)]
     pub use hc_seed_bundle::dependencies::*;
     pub use lair_keystore_api;
     pub use lair_keystore_api::dependencies::*;

--- a/crates/lair_keystore/src/lib.rs
+++ b/crates/lair_keystore/src/lib.rs
@@ -75,6 +75,3 @@ pub mod store_sqlite;
 
 #[doc(inline)]
 pub use store_sqlite::create_sql_pool_factory;
-
-#[cfg(test)]
-mod server_test;

--- a/crates/lair_keystore/src/store_sqlite.rs
+++ b/crates/lair_keystore/src/store_sqlite.rs
@@ -163,18 +163,22 @@ impl SqlPool {
         // initialize the sqlcipher key pragma
         let key_pragma = secure_write_key_pragma(dbk_secret)?;
 
-        // open a single write connection to the database
-        let mut write_con = rusqlite::Connection::open_with_flags(
-            &path,
-            OpenFlags::SQLITE_OPEN_READ_WRITE
-                | OpenFlags::SQLITE_OPEN_CREATE
-                | OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | OpenFlags::SQLITE_OPEN_URI,
-        )
-        .map_err(one_err::OneErr::new)?;
-
-        // set generic pragmas
-        set_pragmas(&write_con, key_pragma.clone())?;
+        let mut write_con = match create_configured_db_connection(&path, key_pragma.clone()) {
+            Ok(con) => con,
+            Err(e) => {
+                if "true" == std::env::var("LAIR_MIGRATE_UNENCRYPTED").unwrap_or_default().as_str() {
+                    // Known SQLite error when the database is not encrypted, try to encrypt it and retry starting the server
+                    if let Some("file is not a database") = e.get_field::<&str, &str>("error") {
+                        encrypt_unencrypted_database(&path, key_pragma.clone())?;
+                        create_configured_db_connection(&path, key_pragma.clone())?
+                    } else {
+                        return Err(e);
+                    }
+                } else {
+                    return Err(e);
+                }
+            }
+        };
 
         // only set WAL mode on the first write connection
         // it's a slow operation, and not needed on subsequent connections.
@@ -287,6 +291,25 @@ impl SqlPool {
             }
         }
     }
+}
+
+fn create_configured_db_connection(path: &std::path::PathBuf, key_pragma: BufRead) -> LairResult<rusqlite::Connection> {
+    use rusqlite::OpenFlags;
+
+    // open a single write connection to the database
+    let write_con = rusqlite::Connection::open_with_flags(
+        &path,
+        OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_CREATE
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(one_err::OneErr::new)?;
+
+    // set generic pragmas
+    set_pragmas(&write_con, key_pragma)?;
+
+    Ok(write_con)
 }
 
 impl AsLairStore for SqlPool {
@@ -500,6 +523,68 @@ fn set_pragmas(
 
     con.pragma_update(None, "synchronous", "1".to_string())
         .map_err(one_err::OneErr::new)?;
+
+    Ok(())
+}
+
+fn encrypt_unencrypted_database(path: &std::path::PathBuf, key_pragma: BufRead) -> LairResult<()> {
+    // e.g. keystore/store_file -> keystore/store_file-encrypted
+    let encrypted_path = path
+        .parent()
+        .ok_or_else(|| -> one_err::OneErr {
+            format!("Database file path has no parent: {:?}", path).into()
+        })?
+        .join(
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .ok_or_else(|| -> one_err::OneErr {
+                    format!("Database file path has no name: {:?}", path).into()
+                })?
+                .to_string()
+                + "-encrypted"
+                + &path
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .map(|p| ".".to_string() + p)
+                    .unwrap_or_default(),
+        );
+
+    tracing::warn!(
+        "Attempting encryption of unencrypted database: {:?} -> {:?}",
+        path,
+        encrypted_path
+    );
+
+    // Migrate the database
+    {
+        let conn = rusqlite::Connection::open(path).map_err(one_err::OneErr::new)?;
+
+        // Ensure everything in the WAL is written to the main database
+        conn.execute("VACUUM", ()).map_err(one_err::OneErr::new)?;
+
+        // Start an exclusive transaction to avoid anybody writing to the database while we're migrating it
+        conn.execute("BEGIN EXCLUSIVE", ()).map_err(one_err::OneErr::new)?;
+
+        let lock = key_pragma.read_lock();
+        conn.execute(
+            "ATTACH DATABASE :db_name AS encrypted KEY :key",
+            rusqlite::named_params! {
+                ":db_name": encrypted_path.to_str(),
+                ":key": &lock[14..81],
+            },
+        ).map_err(one_err::OneErr::new)?;
+
+        conn.query_row("SELECT sqlcipher_export('encrypted')", (), |_| Ok(0)).map_err(one_err::OneErr::new)?;
+
+        conn.execute("COMMIT", ()).map_err(one_err::OneErr::new)?;
+
+        conn.execute("DETACH DATABASE encrypted", ()).map_err(one_err::OneErr::new)?;
+        conn.close().map_err(|(_, err)| err).map_err(one_err::OneErr::new)?;
+    }
+
+    // Swap the databases over
+    std::fs::remove_file(path)?;
+    std::fs::rename(encrypted_path, path)?;
 
     Ok(())
 }

--- a/crates/lair_keystore/src/store_sqlite.rs
+++ b/crates/lair_keystore/src/store_sqlite.rs
@@ -314,7 +314,7 @@ fn create_configured_db_connection(
 
     // open a single write connection to the database
     let write_con = rusqlite::Connection::open_with_flags(
-        &path,
+        path,
         OpenFlags::SQLITE_OPEN_READ_WRITE
             | OpenFlags::SQLITE_OPEN_CREATE
             | OpenFlags::SQLITE_OPEN_NO_MUTEX

--- a/crates/lair_keystore/src/store_sqlite.rs
+++ b/crates/lair_keystore/src/store_sqlite.rs
@@ -122,8 +122,7 @@ impl ExecExt for rusqlite::Connection {
         P: rusqlite::Params,
     {
         use rusqlite::OptionalExtension;
-        self.query_row(sql, params, |_| Ok(()))
-            .optional()?;
+        self.query_row(sql, params, |_| Ok(())).optional()?;
         Ok(())
     }
 }
@@ -165,10 +164,15 @@ impl SqlPool {
         let mut write_con =
             match create_configured_db_connection(&path, key_pragma.clone()) {
                 Ok(con) => con,
-                Err(err @ rusqlite::Error::SqliteFailure(rusqlite::ffi::Error {
-                    code: rusqlite::ffi::ErrorCode::NotADatabase,
-                    ..
-                }, ..)) => {
+                Err(
+                    err @ rusqlite::Error::SqliteFailure(
+                        rusqlite::ffi::Error {
+                            code: rusqlite::ffi::ErrorCode::NotADatabase,
+                            ..
+                        },
+                        ..,
+                    ),
+                ) => {
                     if "true"
                         == std::env::var("LAIR_MIGRATE_UNENCRYPTED")
                             .unwrap_or_default()
@@ -181,7 +185,8 @@ impl SqlPool {
                         create_configured_db_connection(
                             &path,
                             key_pragma.clone(),
-                        ).map_err(one_err::OneErr::new)?
+                        )
+                        .map_err(one_err::OneErr::new)?
                     } else {
                         return Err(one_err::OneErr::new(err));
                     }
@@ -226,7 +231,8 @@ impl SqlPool {
             .map_err(one_err::OneErr::new)?;
 
             // set generic pragmas
-            set_pragmas(&read_con, key_pragma.clone()).map_err(one_err::OneErr::new)?;
+            set_pragmas(&read_con, key_pragma.clone())
+                .map_err(one_err::OneErr::new)?;
 
             *rc_mut = Some(read_con);
         }

--- a/crates/lair_keystore/tests/common.rs
+++ b/crates/lair_keystore/tests/common.rs
@@ -1,0 +1,40 @@
+use lair_keystore::dependencies::*;
+use lair_keystore_api::prelude::*;
+use std::sync::Arc;
+
+pub async fn create_config(tmpdir: &tempdir::TempDir, passphrase: sodoken::BufRead) -> Arc<LairServerConfigInner> {
+    // create the config for the test server
+    Arc::new(
+        hc_seed_bundle::PwHashLimits::Minimum
+            .with_exec(|| {
+                LairServerConfigInner::new(tmpdir.path(), passphrase.clone())
+            })
+            .await
+            .unwrap(),
+    )
+}
+
+pub async fn connect_with_config(config: Arc<LairServerConfigInner>, passphrase: sodoken::BufRead) -> LairResult<lair_keystore_api::LairClient> {
+    // execute the server
+    lair_keystore::server::StandaloneServer::new(config.clone())
+        .await?
+        .run(passphrase.clone())
+        .await?;
+
+    // create a client connection
+    lair_keystore_api::ipc_keystore::ipc_keystore_connect(
+        config.connection_url.clone(),
+        passphrase,
+    )
+    .await
+}
+
+#[allow(dead_code)]
+pub async fn connect(tmpdir: &tempdir::TempDir) -> lair_keystore_api::LairClient {
+    // set up a passphrase
+    let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
+
+    let config = create_config(tmpdir, passphrase.clone()).await;
+
+    connect_with_config(config, passphrase).await.unwrap()
+}

--- a/crates/lair_keystore/tests/common.rs
+++ b/crates/lair_keystore/tests/common.rs
@@ -2,7 +2,10 @@ use lair_keystore::dependencies::*;
 use lair_keystore_api::prelude::*;
 use std::sync::Arc;
 
-pub async fn create_config(tmpdir: &tempdir::TempDir, passphrase: sodoken::BufRead) -> Arc<LairServerConfigInner> {
+pub async fn create_config(
+    tmpdir: &tempdir::TempDir,
+    passphrase: sodoken::BufRead,
+) -> Arc<LairServerConfigInner> {
     // create the config for the test server
     Arc::new(
         hc_seed_bundle::PwHashLimits::Minimum
@@ -14,7 +17,10 @@ pub async fn create_config(tmpdir: &tempdir::TempDir, passphrase: sodoken::BufRe
     )
 }
 
-pub async fn connect_with_config(config: Arc<LairServerConfigInner>, passphrase: sodoken::BufRead) -> LairResult<lair_keystore_api::LairClient> {
+pub async fn connect_with_config(
+    config: Arc<LairServerConfigInner>,
+    passphrase: sodoken::BufRead,
+) -> LairResult<lair_keystore_api::LairClient> {
     // execute the server
     lair_keystore::server::StandaloneServer::new(config.clone())
         .await?
@@ -30,7 +36,9 @@ pub async fn connect_with_config(config: Arc<LairServerConfigInner>, passphrase:
 }
 
 #[allow(dead_code)]
-pub async fn connect(tmpdir: &tempdir::TempDir) -> lair_keystore_api::LairClient {
+pub async fn connect(
+    tmpdir: &tempdir::TempDir,
+) -> lair_keystore_api::LairClient {
     // set up a passphrase
     let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
 

--- a/crates/lair_keystore/tests/migrate_unencrypted.rs
+++ b/crates/lair_keystore/tests/migrate_unencrypted.rs
@@ -1,5 +1,5 @@
+use common::{connect_with_config, create_config};
 use lair_keystore_api::dependencies::{sodoken, tokio};
-use common::{create_config, connect_with_config};
 
 mod common;
 
@@ -10,9 +10,9 @@ async fn migrate_unencrypted() {
     let tmpdir = tempdir::TempDir::new("lair keystore test").unwrap();
 
     let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
-    
+
     let config = create_config(&tmpdir, passphrase.clone()).await;
-    
+
     // Set up an unencrypted database, by not setting a key on the connection
     {
         let conn = Connection::open(&config.store_file).unwrap();
@@ -32,13 +32,15 @@ async fn migrate_unencrypted() {
     match connect_with_config(config.clone(), passphrase.clone()).await {
         Ok(_) => {
             panic!("Shouldn't have been able to spawn lair-keystore");
-        },
+        }
         Err(_) => {
-            // That's good, we shouldn't have been able to connect because the database won't auto-migrate without `LAIR_MIGRATE_UNENCRYPTED` 
+            // That's good, we shouldn't have been able to connect because the database won't auto-migrate without `LAIR_MIGRATE_UNENCRYPTED`
         }
     }
 
     std::env::set_var("LAIR_MIGRATE_UNENCRYPTED", "true");
 
-    connect_with_config(config.clone(), passphrase.clone()).await.unwrap();
+    connect_with_config(config.clone(), passphrase.clone())
+        .await
+        .unwrap();
 }

--- a/crates/lair_keystore/tests/migrate_unencrypted.rs
+++ b/crates/lair_keystore/tests/migrate_unencrypted.rs
@@ -3,6 +3,7 @@ use lair_keystore_api::dependencies::{sodoken, tokio};
 
 mod common;
 
+#[cfg(not(windows))] // No encryption on Windows, ignore this test
 #[tokio::test(flavor = "multi_thread")]
 async fn migrate_unencrypted() {
     use rusqlite::Connection;

--- a/crates/lair_keystore/tests/migrate_unencrypted.rs
+++ b/crates/lair_keystore/tests/migrate_unencrypted.rs
@@ -1,0 +1,44 @@
+use lair_keystore_api::dependencies::{sodoken, tokio};
+use common::{create_config, connect_with_config};
+
+mod common;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn migrate_unencrypted() {
+    use rusqlite::Connection;
+
+    let tmpdir = tempdir::TempDir::new("lair keystore test").unwrap();
+
+    let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
+    
+    let config = create_config(&tmpdir, passphrase.clone()).await;
+    
+    // Set up an unencrypted database, by not setting a key on the connection
+    {
+        let conn = Connection::open(&config.store_file).unwrap();
+
+        // Needs to contain data otherwise encryption will just succeed!
+        conn.execute("CREATE TABLE migrate_me (name TEXT NOT NULL)", ())
+            .unwrap();
+        conn.execute(
+            "INSERT INTO migrate_me (name) VALUES ('hello_migrated')",
+            (),
+        )
+        .unwrap();
+
+        conn.close().unwrap();
+    }
+
+    match connect_with_config(config.clone(), passphrase.clone()).await {
+        Ok(_) => {
+            panic!("Shouldn't have been able to spawn lair-keystore");
+        },
+        Err(_) => {
+            // That's good, we shouldn't have been able to connect because the database won't auto-migrate without `LAIR_MIGRATE_UNENCRYPTED` 
+        }
+    }
+
+    std::env::set_var("LAIR_MIGRATE_UNENCRYPTED", "true");
+
+    connect_with_config(config.clone(), passphrase.clone()).await.unwrap();
+}

--- a/crates/lair_keystore/tests/server_test.rs
+++ b/crates/lair_keystore/tests/server_test.rs
@@ -1,6 +1,6 @@
+use common::connect;
 use lair_keystore::dependencies::*;
 use lair_keystore_api::prelude::*;
-use common::connect;
 
 mod common;
 

--- a/crates/lair_keystore/tests/server_test.rs
+++ b/crates/lair_keystore/tests/server_test.rs
@@ -1,36 +1,8 @@
-use crate::*;
-use std::sync::Arc;
+use lair_keystore::dependencies::*;
+use lair_keystore_api::prelude::*;
+use common::connect;
 
-async fn connect(tmpdir: &tempdir::TempDir) -> lair_keystore_api::LairClient {
-    // set up a passphrase
-    let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
-
-    // create the config for the test server
-    let config = Arc::new(
-        hc_seed_bundle::PwHashLimits::Minimum
-            .with_exec(|| {
-                LairServerConfigInner::new(tmpdir.path(), passphrase.clone())
-            })
-            .await
-            .unwrap(),
-    );
-
-    // execute the server
-    crate::server::StandaloneServer::new(config.clone())
-        .await
-        .unwrap()
-        .run(passphrase.clone())
-        .await
-        .unwrap();
-
-    // create a client connection
-    lair_keystore_api::ipc_keystore::ipc_keystore_connect(
-        config.connection_url.clone(),
-        passphrase,
-    )
-    .await
-    .unwrap()
-}
+mod common;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn server_test_happy_path() {


### PR DESCRIPTION
This is similar to the change I made [here](https://github.com/holochain/holochain/pull/2973).

I know that Lair databases are meant to be encrypted but the `lair_keystore` crate exposes the option to disable database encryption by not using default features, so it would be good if there was a way to migrate if you end up being forcibly switched by something that has embedded Lair and changed it's defaults. Looking at you Holochain :) 