### PR TITLE
Bump the Rust version used by Holochain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         ]
         toolchain: [
           stable,
-          "1.66.1", # Check the version used by Holochain
+          "1.71.1", # Check the version used by Holochain
         ]
     steps:
       - name: Checkout

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -18,7 +18,7 @@ jobs:
         ]
         toolchain: [
           stable,
-          "1.66.1", # Check the version used by Holochain
+          "1.71.1", # Check the version used by Holochain
         ]
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         ]
         toolchain: [
           stable,
-          "1.66.1", # Check the version used by Holochain
+          "1.71.1", # Check the version used by Holochain
         ]
     steps:
       - name: Checkout


### PR DESCRIPTION
Holochain now uses Rust 1.71.1