### PR TITLE
Remove deny warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "hc_seed_bundle"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.13.1",
  "futures",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "criterion",
  "lair_keystore_api",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_cmd",
  "base64 0.13.1",

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ release: tools
 
 static: tools docs
 	cargo fmt -- --check
-	cargo clippy $(FEATURES)
+	cargo clippy $(FEATURES) -- -Dwarnings
 
 docs: tools
 	printf '### `lair-keystore --help`\n```text\n' > crates/lair_keystore/src/docs/help.md.tmp

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ License: MIT OR Apache-2.0
 
 ### `lair-keystore --help`
 ```text
-lair_keystore 0.4.1
+lair_keystore 0.4.2
 secret lair private keystore
 
 USAGE:
@@ -74,7 +74,7 @@ SUBCOMMANDS:
 ```
 ### `lair-keystore init --help`
 ```text
-lair-keystore-init 0.4.1
+lair-keystore-init 0.4.2
 Set up a new lair private keystore.
 
 USAGE:
@@ -92,7 +92,7 @@ FLAGS:
 ```
 ### `lair-keystore url --help`
 ```text
-lair-keystore-url 0.4.1
+lair-keystore-url 0.4.2
 Print the connection_url for a configured lair-keystore
 server to stdout and exit.
 
@@ -106,7 +106,7 @@ FLAGS:
 ```
 ### `lair-keystore import-seed --help`
 ```text
-lair-keystore-import-seed 0.4.1
+lair-keystore-import-seed 0.4.2
 Load a seed bundle into this lair-keystore instance.
 Note, this operation requires capturing the pid_file,
 make sure you do not have a lair-server running.
@@ -143,7 +143,7 @@ ARGS:
 ```
 ### `lair-keystore server --help`
 ```text
-lair-keystore-server 0.4.1
+lair-keystore-server 0.4.2
 Run a lair keystore server instance. Note you must
 have initialized a config file first with
 'lair-keystore init'.

--- a/crates/hc_seed_bundle/Cargo.toml
+++ b/crates/hc_seed_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc_seed_bundle"
-version = "0.2.0"
+version = "0.2.1"
 description = "SeedBundle parsing and generation library."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/holochain/lair"

--- a/crates/hc_seed_bundle/src/lib.rs
+++ b/crates/hc_seed_bundle/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::new_without_default)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
-#![deny(warnings)]
+
 //! SeedBundle parsing and generation library.
 //!
 //! [![Project](https://img.shields.io/badge/project-holochain-blue.svg?style=flat-square)](http://holochain.org/)

--- a/crates/lair_keystore/Cargo.toml
+++ b/crates/lair_keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lair_keystore"
-version = "0.4.1"
+version = "0.4.2"
 description = "secret lair private keystore"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/holochain/lair"
@@ -19,7 +19,7 @@ rusqlite-sqlcipher = [ "rusqlite/sqlcipher" ]
 
 [dependencies]
 # lair_keystore_api must be pinned to enable strict version checks
-lair_keystore_api = { version = "=0.4.1", path = "../lair_keystore_api" }
+lair_keystore_api = { version = "=0.4.2", path = "../lair_keystore_api" }
 rpassword = "7.2.0"
 rusqlite = { version = "0.29", features = [ "modern_sqlite" ] }
 structopt = "0.3.26"
@@ -27,7 +27,7 @@ sysinfo = "0.28.4"
 tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
 
 [build-dependencies]
-lair_keystore_api = { version = "0.4.1", path = "../lair_keystore_api" }
+lair_keystore_api = { version = "0.4.2", path = "../lair_keystore_api" }
 pretty_assertions = "1.3.0"
 sqlformat = "0.2.1"
 

--- a/crates/lair_keystore/README.md
+++ b/crates/lair_keystore/README.md
@@ -43,7 +43,7 @@ License: MIT OR Apache-2.0
 
 ### `lair-keystore --help`
 ```text
-lair_keystore 0.4.1
+lair_keystore 0.4.2
 secret lair private keystore
 
 USAGE:
@@ -74,7 +74,7 @@ SUBCOMMANDS:
 ```
 ### `lair-keystore init --help`
 ```text
-lair-keystore-init 0.4.1
+lair-keystore-init 0.4.2
 Set up a new lair private keystore.
 
 USAGE:
@@ -92,7 +92,7 @@ FLAGS:
 ```
 ### `lair-keystore url --help`
 ```text
-lair-keystore-url 0.4.1
+lair-keystore-url 0.4.2
 Print the connection_url for a configured lair-keystore
 server to stdout and exit.
 
@@ -106,7 +106,7 @@ FLAGS:
 ```
 ### `lair-keystore import-seed --help`
 ```text
-lair-keystore-import-seed 0.4.1
+lair-keystore-import-seed 0.4.2
 Load a seed bundle into this lair-keystore instance.
 Note, this operation requires capturing the pid_file,
 make sure you do not have a lair-server running.
@@ -143,7 +143,7 @@ ARGS:
 ```
 ### `lair-keystore server --help`
 ```text
-lair-keystore-server 0.4.1
+lair-keystore-server 0.4.2
 Run a lair keystore server instance. Note you must
 have initialized a config file first with
 'lair-keystore init'.

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/main.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/main.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::new_without_default)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
-#![deny(warnings)]
 
 //! sqlite/sqlcipher backed LairKeystore server control binary
 

--- a/crates/lair_keystore/src/docs/help.md
+++ b/crates/lair_keystore/src/docs/help.md
@@ -1,6 +1,6 @@
 ### `lair-keystore --help`
 ```text
-lair_keystore 0.4.1
+lair_keystore 0.4.2
 secret lair private keystore
 
 USAGE:

--- a/crates/lair_keystore/src/docs/import-seed-help.md
+++ b/crates/lair_keystore/src/docs/import-seed-help.md
@@ -1,6 +1,6 @@
 ### `lair-keystore import-seed --help`
 ```text
-lair-keystore-import-seed 0.4.1
+lair-keystore-import-seed 0.4.2
 Load a seed bundle into this lair-keystore instance.
 Note, this operation requires capturing the pid_file,
 make sure you do not have a lair-server running.

--- a/crates/lair_keystore/src/docs/init-help.md
+++ b/crates/lair_keystore/src/docs/init-help.md
@@ -1,6 +1,6 @@
 ### `lair-keystore init --help`
 ```text
-lair-keystore-init 0.4.1
+lair-keystore-init 0.4.2
 Set up a new lair private keystore.
 
 USAGE:

--- a/crates/lair_keystore/src/docs/server-help.md
+++ b/crates/lair_keystore/src/docs/server-help.md
@@ -1,6 +1,6 @@
 ### `lair-keystore server --help`
 ```text
-lair-keystore-server 0.4.1
+lair-keystore-server 0.4.2
 Run a lair keystore server instance. Note you must
 have initialized a config file first with
 'lair-keystore init'.

--- a/crates/lair_keystore/src/docs/url-help.md
+++ b/crates/lair_keystore/src/docs/url-help.md
@@ -1,6 +1,6 @@
 ### `lair-keystore url --help`
 ```text
-lair-keystore-url 0.4.1
+lair-keystore-url 0.4.2
 Print the connection_url for a configured lair-keystore
 server to stdout and exit.
 

--- a/crates/lair_keystore/src/lib.rs
+++ b/crates/lair_keystore/src/lib.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::new_without_default)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
-#![deny(warnings)]
 
 //! Secret lair private keystore
 //!

--- a/crates/lair_keystore_api/Cargo.toml
+++ b/crates/lair_keystore_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lair_keystore_api"
-version = "0.4.1"
+version = "0.4.2"
 description = "secret lair private keystore API library"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/holochain/lair"
@@ -15,7 +15,7 @@ base64 = "0.13.1"
 dunce = "1.0.4"
 # this doesn't strictly need to be pinned, but it supports the
 # determinism of the strict client/server version checks
-hc_seed_bundle = { version = "=0.2.0", path = "../hc_seed_bundle" }
+hc_seed_bundle = { version = "=0.2.1", path = "../hc_seed_bundle" }
 lru = "0.10.0"
 nanoid = "0.4.0"
 once_cell = "1.17.1"

--- a/crates/lair_keystore_api/src/lib.rs
+++ b/crates/lair_keystore_api/src/lib.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::new_without_default)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
-#![deny(warnings)]
 
 //! Secret lair private keystore API library.
 //!


### PR DESCRIPTION
### Summary

As discussed, remove deny warnings and rely on CI to catch warnings. See recommendations from clippy [docs](https://doc.rust-lang.org/stable/clippy/usage.html#command-line)

I've also bumped the versions in the same PR so I can release this once the PR is in

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info