### PR TITLE
feat: set tracing to output to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Set tracing writer to write to `stderr` instead of `stdout` [#138](https://github.com/holochain/lair/pull/138)
+- The `lair-keystore` binary now exits with an error (exit code `1`) if and error occurs [#138](https://github.com/holochain/lair/pull/138)
+
 ## 0.5.2
 
 - enables some basic tracing [#135](https://github.com/holochain/lair/pull/135)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
 name = "lair_keystore"
 version = "0.5.2"
 dependencies = [
+ "assert_cmd",
  "criterion",
  "lair_keystore_api",
  "pretty_assertions",

--- a/crates/lair_keystore/Cargo.toml
+++ b/crates/lair_keystore/Cargo.toml
@@ -34,6 +34,7 @@ pretty_assertions = { workspace = true }
 sqlformat = { workspace = true }
 
 [dev-dependencies]
+assert_cmd = { workspace = true }
 criterion = { workspace = true }
 tempdir = { workspace = true }
 

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/main.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/main.rs
@@ -195,6 +195,7 @@ async fn exec() -> LairResult<()> {
     tracing::subscriber::set_global_default(
         tracing_subscriber::FmtSubscriber::builder()
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_writer(std::io::stderr)
             .compact()
             .finish(),
     )

--- a/crates/lair_keystore/src/bin/lair-keystore-bin/main.rs
+++ b/crates/lair_keystore/src/bin/lair-keystore-bin/main.rs
@@ -224,8 +224,6 @@ async fn exec() -> LairResult<()> {
 }
 
 #[tokio::main(flavor = "multi_thread")]
-async fn main() {
-    if let Err(e) = exec().await {
-        eprintln!("{e}");
-    }
+async fn main() -> LairResult<()> {
+    exec().await
 }

--- a/crates/lair_keystore/tests/client_commands.rs
+++ b/crates/lair_keystore/tests/client_commands.rs
@@ -1,0 +1,29 @@
+mod common;
+
+use assert_cmd::Command;
+use common::create_config;
+use lair_keystore::dependencies::*;
+use std::{fs::File, io::Write};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_url_command_only_outputs_connection_url() {
+    let tmp_dir = tempdir::TempDir::new("lair keystore test").unwrap();
+    let passphrase = sodoken::BufRead::from(&b"passphrase"[..]);
+
+    let config = create_config(&tmp_dir, passphrase.clone()).await;
+    let config_path = tmp_dir.path().join("lair-keystore-config.yaml");
+    let mut config_file =
+        File::create_new(config_path).expect("test config file already exists");
+
+    config_file
+        .write_all(config.to_string().as_bytes())
+        .expect("failed to write config to file");
+
+    let mut cmd = Command::cargo_bin("lair-keystore").unwrap();
+    cmd.env("RUST_LOG", "trace"); // Enable all logging levels to make sure nothing gets printed to stdout
+    cmd.arg(format!("--lair-root={}", tmp_dir.path().display()));
+    cmd.arg("url");
+
+    let expected_stdout = format!("{}\n", config.connection_url);
+    cmd.assert().success().stdout(expected_stdout);
+}


### PR DESCRIPTION
### Summary
As reported in issue #137, the output of the `url` command is supposed to just be the `connection_url`. This PR sets the tracing output to `stderr` to keep `stdout` clean of logs.

Closes #137

### TODO:
- [x] Add some tests to make sure the `url` command outputs correctly on stdout.
- [x] CHANGELOG(s) updated with appropriate info