### PR TITLE
chore: Bump to Rust 1.85

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         ]
         toolchain: [
           stable,
-          "1.83.0", # Check the version used by Holochain
+          "1.85.0", # Check the version used by Holochain
         ]
     steps:
       - name: Checkout

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -18,7 +18,7 @@ jobs:
         ]
         toolchain: [
           stable,
-          "1.83.0", # Check the version used by Holochain
+          "1.85.0", # Check the version used by Holochain
         ]
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         ]
         toolchain: [
           stable,
-          "1.83.0", # Check the version used by Holochain
+          "1.85.0", # Check the version used by Holochain
         ]
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Update to Rust 1.85 [#144](https://github.com/holochain/lair/pull/144)
+- Update to latest `sodoken` version, comes with breaking changes to the Lair API to switch from read buffers to locked 
+  arrays. See the documentation for updated usage examples. [#143](https://github.com/holochain/lair/pull/143)
+
 ## 0.5.3
 
 - Upgrade `sysinfo` dependency to resolve an issue with building against a recent libc [#140](https://github.com/holochain/lair/pull/140)

--- a/crates/hc_seed_bundle/tests/execute_fixture_tests.rs
+++ b/crates/hc_seed_bundle/tests/execute_fixture_tests.rs
@@ -142,7 +142,7 @@ impl Test {
                 cur = cur.derive(subkey_id.parse().unwrap()).await.unwrap();
             }
 
-            assert_eq_b64(target.as_str(), &cur.get_sign_pub_key().as_slice());
+            assert_eq_b64(target.as_str(), cur.get_sign_pub_key().as_slice());
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.85.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
### Summary

Apparently the code here was in good shape, minimal changes needed to update to Rust 1.85

### TODO:
- [x] CHANGELOG(s) updated with appropriate info