### PR TITLE
ci: Update release integration action versions

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   call:
-    uses: holochain/actions/.github/workflows/prepare-release.yml@v1.0.0
+    uses: holochain/actions/.github/workflows/prepare-release.yml@v1.2.0
     with:
       cliff_config: "https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml"
       force_version: ${{ inputs.force_version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   call:
-    uses: holochain/actions/.github/workflows/publish-release.yml@v1.0.0
+    uses: holochain/actions/.github/workflows/publish-release.yml@v1.2.0
     secrets:
       HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
       HRA2_CRATES_IO_TOKEN: ${{ secrets.HRA2_CRATES_IO_TOKEN }}


### PR DESCRIPTION
### Summary

I'm not able to do a release without this upgrade. I just tried running the release tool locally to see what was wrong on CI and it worked fine. So CI is running into a bug that is already fixed.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded internal release automation to a newer stable upstream for preparing and publishing releases.
  * Background workflows now reference the latest stable versions, incorporating recent upstream improvements.
  * Release triggers, steps, and configuration remain unchanged.
  * No impact on user-facing features, app behavior, or versioning logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->